### PR TITLE
feat: internal iterative reductions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -242,7 +242,7 @@ impl Search {
         let static_eval = tt_eval.unwrap_or(self.position.eval());
 
         // internal iterative reduction
-        if !is_root && is_pv && depth >= 4 && !self.position.in_check() && tt_move == Move::NONE {
+        if !is_root && depth >= 6 && !self.position.in_check() && tt_move == Move::NONE {
             depth -= 1;
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -241,6 +241,11 @@ impl Search {
 
         let static_eval = tt_eval.unwrap_or(self.position.eval());
 
+        // internal iterative reduction
+        if !is_root && is_pv && depth >= 4 && !self.position.in_check() && tt_move == Move::NONE {
+            depth -= 1;
+        }
+
         // Null move pruning
         if !is_pv
             && depth >= 3


### PR DESCRIPTION
```
Results of iir vs base (4+0.04, NULL, 16MB, noob_3moves.pgn):
Elo: 23.65 +/- 14.09, nElo: 30.21 +/- 17.93
LOS: 99.95 %, DrawRatio: 35.92 %, PairsRatio: 1.38
Games: 1442, Wins: 500, Losses: 402, Draws: 540, Points: 770.0 (53.40 %)
Ptnml(0-2): [60, 134, 259, 184, 84], WL/DD Ratio: 1.33
LLR: 2.98 (-2.94, 2.94) [0.00, 10.00]
```
