### PR TITLE
tune: history and aspiration window tweaks

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -361,7 +361,7 @@ impl Search {
                 }
             }
 
-            if !capture {
+            if !capture && quiets.len() < quiets.capacity() {
                 quiets.push(mv);
             }
         }


### PR DESCRIPTION
```
Results of history-tweaks vs base (4+0.04, NULL, 16MB, noob_3moves.pgn):
Elo: 15.76 +/- 10.97, nElo: 20.08 +/- 13.95
LOS: 99.76 %, DrawRatio: 33.50 %, PairsRatio: 1.21
Games: 2382, Wins: 788, Losses: 680, Draws: 914, Points: 1245.0 (52.27 %)
Ptnml(0-2): [98, 260, 399, 304, 130], WL/DD Ratio: 1.28
LLR: 2.96 (-2.94, 2.94) [0.00, 10.00]
```
