### PR TITLE
fix: fix tt entry type issue and en passant zobrist calculation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,152 @@
+{
+    "resign": {
+        "move_count": 1,
+        "score": 0,
+        "twosided": false,
+        "enabled": false
+    },
+    "draw": {
+        "move_number": 0,
+        "move_count": 1,
+        "score": 0,
+        "enabled": false
+    },
+    "maxmoves": {
+        "move_count": 1,
+        "enabled": false
+    },
+    "opening": {
+        "file": "books/noob_3moves.pgn",
+        "format": 1,
+        "order": 0,
+        "plies": -1,
+        "start": 1
+    },
+    "pgn": {
+        "additional_lines_rgx": [],
+        "event_name": "Fastchess Tournament",
+        "site": "?",
+        "file": "",
+        "notation": 0,
+        "track_nodes": false,
+        "track_seldepth": false,
+        "track_nps": false,
+        "track_hashfull": false,
+        "track_tbhits": false,
+        "track_timeleft": false,
+        "track_latency": false,
+        "min": false,
+        "crc": false
+    },
+    "epd": {
+        "file": ""
+    },
+    "sprt": {
+        "alpha": 0.05,
+        "beta": 0.05,
+        "elo0": -10.0,
+        "elo1": 0.0,
+        "model": "normalized",
+        "enabled": true
+    },
+    "config_name": "",
+    "output": 0,
+    "seed": 1857325538804493573,
+    "variant": 0,
+    "ratinginterval": 10,
+    "scoreinterval": 1,
+    "wait": 0,
+    "autosaveinterval": 20,
+    "games": 2,
+    "rounds": 10000,
+    "concurrency": 10,
+    "force_concurrency": false,
+    "recover": true,
+    "noswap": false,
+    "reverse": false,
+    "report_penta": true,
+    "affinity": false,
+    "show_latency": false,
+    "log": {
+        "file": "",
+        "level": 2,
+        "compress": false,
+        "realtime": true
+    },
+    "engines": [
+        {
+            "name": "1",
+            "dir": "",
+            "cmd": "target/release/pounce",
+            "args": "",
+            "restart": false,
+            "options": [
+                [
+                    "Hash",
+                    "16"
+                ]
+            ],
+            "limit": {
+                "tc": {
+                    "increment": 100,
+                    "fixed_time": 0,
+                    "time": 10000,
+                    "moves": 0,
+                    "timemargin": 0
+                },
+                "nodes": 0,
+                "plies": 0
+            },
+            "variant": 0
+        },
+        {
+            "name": "2",
+            "dir": "",
+            "cmd": "target/release/pounce",
+            "args": "",
+            "restart": false,
+            "options": [
+                [
+                    "Hash",
+                    "16"
+                ]
+            ],
+            "limit": {
+                "tc": {
+                    "increment": 100,
+                    "fixed_time": 0,
+                    "time": 10000,
+                    "moves": 0,
+                    "timemargin": 0
+                },
+                "nodes": 0,
+                "plies": 0
+            },
+            "variant": 0
+        }
+    ],
+    "stats": {
+        "1 vs 2": {
+            "wins": 3,
+            "losses": 4,
+            "draws": 7,
+            "penta_WW": 0,
+            "penta_WD": 2,
+            "penta_WL": 1,
+            "penta_DD": 1,
+            "penta_LD": 3,
+            "penta_LL": 0
+        },
+        "2 vs 1": {
+            "wins": 7,
+            "losses": 5,
+            "draws": 4,
+            "penta_WW": 1,
+            "penta_WD": 3,
+            "penta_WL": 2,
+            "penta_DD": 0,
+            "penta_LD": 1,
+            "penta_LL": 1
+        }
+    }
+}

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -336,13 +336,12 @@ impl Position {
             key: self.key,
         };
 
+        // reset the en passant square
         let prev_ep_square = self.ep_square;
-
         self.key.toggle_ep(self.ep_square);
         self.ep_square = None;
-        self.halfmove_clock += 1;
 
-        // reset the en passant square
+        self.halfmove_clock += 1;
 
         match mv.move_type(piece.role, prev_ep_square) {
             MoveType::Normal => {
@@ -354,8 +353,13 @@ impl Position {
                 self.discard(from, piece);
                 self.set(to, piece);
 
-                self.ep_square = Some(from.up(self.side).unwrap());
-                self.key.toggle_ep(self.ep_square);
+                let potential_ep_sq = from.up(self.side).unwrap();
+                if get_pawn_attacks(potential_ep_sq, self.side) & self.their(Role::Pawn)
+                    != Bitboard::EMPTY
+                {
+                    self.ep_square = Some(potential_ep_sq);
+                    self.key.toggle_ep(self.ep_square);
+                }
             }
             MoveType::EnPassant => {
                 // unwrapping is safe here because we know ep_square is never at the edge of the
@@ -625,6 +629,48 @@ impl Position {
                 let us = self.us();
                 self.pinned |= btw & us;
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{chess::position::fen::Fen, init};
+
+    use super::*;
+
+    #[test]
+    fn test_repetitions() {
+        init();
+
+        let Fen(mut position) =
+            Fen::parse("rnb1kbnr/1pqppppp/p7/2p5/4P3/2N2Q2/PPPP1PPP/R1B1KBNR w KQkq - 0 1")
+                .unwrap();
+        let move_str = "f3g3 d7d6 c3d5 c7d8 g1f3 e7e6 d5e3 g8f6 d2d3 b8c6 c1d2 g7g6 e1c1 f8g7 f1e2 e8g8 h2h3 d6d5 e4d5 e6d5 e3g4 f6g4 h3g4 f8e8 h1e1 h7h6 c1b1 c8e6 g4g5 d8b6 b2b3 h6h5 d2f4 a8c8 a2a4";
+
+        let zero_repetition = "g7c3 f4d2 c3g7";
+        let one_repetition = "d2f4 g7c3 f4d2 c3g7";
+        let two_repetition = "d2f4";
+
+        for mv in move_str.split_whitespace() {
+            position.make_move(mv.parse::<Move>().unwrap());
+            assert!(!position.is_repetition(1));
+            assert!(!position.is_repetition(2));
+        }
+
+        for mv in zero_repetition.split_whitespace() {
+            position.make_move(mv.parse::<Move>().unwrap());
+            assert!(!position.is_repetition(1));
+        }
+
+        for mv in one_repetition.split_whitespace() {
+            position.make_move(mv.parse::<Move>().unwrap());
+            assert!(position.is_repetition(1));
+        }
+
+        for mv in two_repetition.split_whitespace() {
+            position.make_move(mv.parse::<Move>().unwrap());
+            assert!(position.is_repetition(2));
         }
     }
 }

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -649,9 +649,9 @@ impl Position {
 
 #[cfg(test)]
 mod test {
-    use crate::{chess::position::fen::Fen, init};
-
     use super::*;
+    use crate::chess::position::fen::Fen;
+    use crate::init;
 
     #[test]
     fn test_repetitions() {

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -343,6 +343,9 @@ impl Position {
 
         self.halfmove_clock += 1;
 
+        let mut potential_ep_sq = None;
+        let mut ep_attackers = Bitboard::EMPTY;
+
         match mv.move_type(piece.role, prev_ep_square) {
             MoveType::Normal => {
                 state.captured = self.piece_at(to);
@@ -353,13 +356,12 @@ impl Position {
                 self.discard(from, piece);
                 self.set(to, piece);
 
-                let potential_ep_sq = from.up(self.side).unwrap();
-                if get_pawn_attacks(potential_ep_sq, self.side) & self.their(Role::Pawn)
-                    != Bitboard::EMPTY
-                {
-                    self.ep_square = Some(potential_ep_sq);
-                    self.key.toggle_ep(self.ep_square);
-                }
+                potential_ep_sq = from.up(self.side);
+
+                ep_attackers =
+                    get_pawn_attacks(potential_ep_sq.unwrap(), self.side) & self.their(Role::Pawn);
+
+                // we handle setting the ep square below, after we've updated the checkers and pins
             }
             MoveType::EnPassant => {
                 // unwrapping is safe here because we know ep_square is never at the edge of the
@@ -436,6 +438,18 @@ impl Position {
 
         self.side = self.side.opponent();
         self.key.toggle_side();
+
+        // handle ep square here (after updating checks and pins)
+        // only set ep square if the attacker if the ep move is legal
+        if let Some(ep_sq) = potential_ep_sq {
+            if (ep_attackers & !self.pinned).any()
+                && (!self.checkers.any()
+                    || self.checkers == Bitboard::from(ep_sq.down(self.side).unwrap()))
+            {
+                self.ep_square = Some(ep_sq);
+                self.key.toggle_ep(self.ep_square);
+            }
+        }
     }
 
     pub fn unmake_move(&mut self, mv: Move) {
@@ -672,5 +686,44 @@ mod test {
             position.make_move(mv.parse::<Move>().unwrap());
             assert!(position.is_repetition(2));
         }
+    }
+
+    #[test]
+    fn test_en_passant_legal() {
+        init();
+
+        let Fen(mut position) =
+            Fen::parse("rnbq1bnr/pp1ppppp/2k5/8/2p5/8/PP1PPPPP/2Q1KBNR w K - 0 1").unwrap();
+
+        assert_eq!(position.ep_square, None);
+        position.make_move("b2b4".parse::<Move>().unwrap());
+
+        assert_eq!(position.ep_square, None);
+    }
+
+    #[test]
+    fn test_en_passant_not_allowed_while_checked() {
+        init();
+
+        let Fen(mut position) =
+            Fen::parse("rnbq1bnr/pp1ppppp/8/8/2p5/8/QPkPPPPP/4KBNR w K - 0 1").unwrap();
+
+        assert_eq!(position.ep_square, None);
+        position.make_move("b2b4".parse::<Move>().unwrap());
+
+        assert_eq!(position.ep_square, None);
+    }
+
+    #[test]
+    fn test_en_passant_allowed_while_checked() {
+        init();
+
+        let Fen(mut position) =
+            Fen::parse("rnbq1bnr/pp1ppppp/8/2k5/2p5/8/QP1PPPPP/4KBNR w K - 0 1").unwrap();
+
+        assert_eq!(position.ep_square, None);
+        position.make_move("b2b4".parse::<Move>().unwrap());
+
+        assert_eq!(position.ep_square, Some(Square::B3));
     }
 }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -422,7 +422,7 @@ impl<'a> Search<'a> {
         } else if is_pv && best_move != Move::NULL {
             EntryType::Exact
         } else {
-            EntryType::LowerBound
+            EntryType::UpperBound
         };
 
         if !self.stop.load(std::sync::atomic::Ordering::Relaxed) {


### PR DESCRIPTION
Results of bug-fix vs main (10+0.1, 1t, 16MB, noob_3moves.pgn):
Elo: 108.06 +/- 33.07, nElo: 139.31 +/- 39.85
LOS: 100.00 %, DrawRatio: 28.77 %, PairsRatio: 3.95
Games: 292, Wins: 131, Losses: 43, Draws: 118, Points: 190.0 (65.07 %)
Ptnml(0-2): [6, 15, 42, 51, 32], WL/DD Ratio: 0.62
LLR: 2.95 (-2.94, 2.94) [-10.00, 0.00]