### PR TITLE
add rating estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A UCI compatible chess engine written in Rust.
 
+## Rating History
+
+| Version | Estimated Elo |
+---------------------------
+| 1.2.4   | ~2500       |
+
 ## Features
 
 * Fast, bitboard based move generation


### PR DESCRIPTION
Rating estimate added to readme based on the following tournament (ran at 10+0.1 16mb@1th).

```
Rank Name                             Elo        +/-       nElo        +/-      Games      Score       Draw           Ptnml(0-2)
   1 1.2.4                          66.66      32.42      82.28      38.93        306      59.5%      35.9%  [8, 24, 55, 34, 32]
   2 kimbo                         -10.22      33.77     -11.83      38.93        306      48.5%      32.7% [23, 31, 50, 30, 19]
   3 ShenYu                        -20.46      31.66     -25.29      38.93        306      47.1%      32.7% [22, 33, 50, 37, 11]
   4 Loki3                         -35.32      32.74     -42.42      38.93        306      44.9%      38.6% [25, 33, 59, 20, 16]

```