### PR TITLE
more ep fixes

### DIFF
--- a/src/chess/bitboard.rs
+++ b/src/chess/bitboard.rs
@@ -19,7 +19,7 @@ impl Bitboard {
 
     #[inline]
     pub fn contains(self, sq: Square) -> bool {
-        (self & Bitboard::from(sq)).any()
+        (self & sq).any()
     }
 
     #[inline]
@@ -34,12 +34,12 @@ impl Bitboard {
 
     #[inline]
     pub fn clear(&mut self, sq: Square) {
-        *self &= !Bitboard::from(sq);
+        *self &= sq;
     }
 
     #[inline]
     pub fn toggle(&mut self, sq: Square) {
-        *self ^= Bitboard::from(sq);
+        *self ^= sq;
     }
 
     #[inline]

--- a/src/chess/bitboard.rs
+++ b/src/chess/bitboard.rs
@@ -29,12 +29,12 @@ impl Bitboard {
 
     #[inline]
     pub fn set(&mut self, sq: Square) {
-        *self |= Bitboard::from(sq);
+        *self |= sq;
     }
 
     #[inline]
     pub fn clear(&mut self, sq: Square) {
-        *self &= sq;
+        *self &= !Bitboard::from(sq);
     }
 
     #[inline]
@@ -276,7 +276,7 @@ impl Iterator for Bitboard {
             return None;
         }
         let sq = Square::new_unchecked(self.0.trailing_zeros() as u8);
-        *self ^= Bitboard::from(sq);
+        *self ^= sq;
         Some(sq)
     }
 }

--- a/src/chess/chessmove.rs
+++ b/src/chess/chessmove.rs
@@ -3,10 +3,9 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-use crate::chess::Position;
 use crate::chess::board::ParseSquareError;
 use crate::chess::piece::ParseRoleError;
-use crate::chess::{Role, Square};
+use crate::chess::{Position, Role, Square};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoveType {

--- a/src/chess/chessmove.rs
+++ b/src/chess/chessmove.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
+use crate::chess::Position;
 use crate::chess::board::ParseSquareError;
 use crate::chess::piece::ParseRoleError;
 use crate::chess::{Role, Square};
@@ -64,6 +65,27 @@ impl Move {
             }
         } else {
             MoveType::Normal
+        }
+    }
+
+    pub fn is_capture(self, pos: &Position) -> bool {
+        pos.occupancy.contains(self.to())
+            || self.move_type(Role::Pawn, pos.ep_square) == MoveType::EnPassant
+    }
+
+    pub fn is_quiet(self, pos: &Position) -> bool {
+        !self.is_capture(pos) && self.move_type(Role::Pawn, pos.ep_square) != MoveType::Promotion
+    }
+
+    pub fn is_promotion(self) -> bool {
+        self.promotion().is_some()
+    }
+
+    pub fn captured_role(self, pos: &Position) -> Option<Role> {
+        if self.move_type(Role::Pawn, pos.ep_square) == MoveType::EnPassant {
+            Some(Role::Pawn)
+        } else {
+            pos.role_at(self.to())
         }
     }
 

--- a/src/chess/chessmove.rs
+++ b/src/chess/chessmove.rs
@@ -46,6 +46,7 @@ impl Move {
     }
 
     // This only works for valid moves
+    #[inline]
     pub fn move_type(self, role: Role, ep_square: Option<Square>) -> MoveType {
         if self.promotion().is_some() {
             MoveType::Promotion
@@ -67,25 +68,32 @@ impl Move {
         }
     }
 
+    #[inline]
     pub fn is_capture(self, pos: &Position) -> bool {
         pos.occupancy.contains(self.to())
-            || self.move_type(Role::Pawn, pos.ep_square) == MoveType::EnPassant
+            || self.move_type(pos.role_at(self.from()).unwrap(), pos.ep_square)
+                == MoveType::EnPassant
     }
 
     pub fn is_quiet(self, pos: &Position) -> bool {
-        !self.is_capture(pos) && self.move_type(Role::Pawn, pos.ep_square) != MoveType::Promotion
+        !self.is_capture(pos)
+            && self.move_type(pos.role_at(self.from()).unwrap(), pos.ep_square)
+                != MoveType::Promotion
     }
 
     pub fn is_promotion(self) -> bool {
         self.promotion().is_some()
     }
 
+    #[inline]
     pub fn captured_role(self, pos: &Position) -> Option<Role> {
-        if self.move_type(Role::Pawn, pos.ep_square) == MoveType::EnPassant {
-            Some(Role::Pawn)
-        } else {
-            pos.role_at(self.to())
-        }
+        pos.role_at(self.to()).or_else(|| {
+            if self.is_capture(pos) {
+                Some(Role::Pawn)
+            } else {
+                None
+            }
+        })
     }
 
     pub const NULL: Move = Move(u16::MAX);

--- a/src/chess/movegen/king.rs
+++ b/src/chess/movegen/king.rs
@@ -66,7 +66,7 @@ impl Mover for KingType {
 
         if moves != Bitboard::EMPTY {
             unsafe {
-                movelist.push_unchecked(FromAndMoves::new(ksq, moves, false));
+                movelist.push_unchecked(FromAndMoves::new(ksq, moves, false, false));
             }
         }
     }

--- a/src/chess/movegen/pawn.rs
+++ b/src/chess/movegen/pawn.rs
@@ -58,6 +58,7 @@ impl Mover for PawnType {
                         sq,
                         moves,
                         promotion_bb & Bitboard::from(sq) != Bitboard::EMPTY,
+                        false,
                     ));
                 }
             }
@@ -72,6 +73,7 @@ impl Mover for PawnType {
                             sq,
                             moves,
                             promotion_bb & Bitboard::from(sq) != Bitboard::EMPTY,
+                            false,
                         ));
                     }
                 }
@@ -85,7 +87,12 @@ impl Mover for PawnType {
             for sq in ep_source_squares {
                 if Self::legal_ep_move::<BLACK>(sq, ep, pos) {
                     unsafe {
-                        movelist.push_unchecked(FromAndMoves::new(sq, Bitboard::from(ep), false));
+                        movelist.push_unchecked(FromAndMoves::new(
+                            sq,
+                            Bitboard::from(ep),
+                            false,
+                            true,
+                        ));
                     }
                 }
             }

--- a/src/chess/movegen/types.rs
+++ b/src/chess/movegen/types.rs
@@ -11,14 +11,16 @@ pub struct FromAndMoves {
     from: Square,
     moves: Bitboard,
     is_promotion: bool,
+    is_ep: bool,
 }
 
 impl FromAndMoves {
-    pub fn new(from: Square, moves: Bitboard, is_promotion: bool) -> Self {
+    pub fn new(from: Square, moves: Bitboard, is_promotion: bool, is_ep: bool) -> Self {
         FromAndMoves {
             from,
             moves,
             is_promotion,
+            is_ep,
         }
     }
 }
@@ -48,6 +50,7 @@ pub struct MoveGen {
     index: usize,
     promotion_index: PromotionIndex,
     iter_mask: Bitboard,
+    captures_only: bool,
 }
 
 impl MoveGen {
@@ -109,12 +112,25 @@ impl MoveGen {
             index: 0,
             promotion_index: PromotionIndex::Queen,
             iter_mask: Bitboard::FULL,
+            captures_only: false,
         }
     }
 
     pub fn set_mask(&mut self, mask: Bitboard) {
         self.index = 0;
         self.iter_mask = mask;
+    }
+
+    pub fn set_captures_only(&mut self, occupancy: Bitboard) {
+        self.index = 0;
+        self.iter_mask = occupancy;
+        self.captures_only = true;
+    }
+
+    pub fn disable_captures_only(&mut self) {
+        self.index = 0;
+        self.iter_mask = Bitboard::FULL;
+        self.captures_only = false;
     }
 }
 
@@ -147,6 +163,7 @@ impl Iterator for MoveGen {
         } else if self.moves[self.index].is_promotion {
             let moves = &mut self.moves[self.index];
             let masked = moves.moves & self.iter_mask;
+
             if masked == Bitboard::EMPTY {
                 self.index += 1;
                 return self.next();
@@ -179,11 +196,21 @@ impl Iterator for MoveGen {
             }
         } else {
             let moves = &mut self.moves[self.index];
-            let masked = moves.moves & self.iter_mask;
+
+            // skip moves that are not in the mask,
+            // but make sure that if we are generating captures only,
+            // we do not skip en passant moves (which are not in the mask)
+            let masked = if self.captures_only && moves.is_ep {
+                moves.moves // Use the original moves (the EP target square)
+            } else {
+                moves.moves & self.iter_mask
+            };
+
             if masked == Bitboard::EMPTY {
                 self.index += 1;
                 return self.next();
             }
+
             let to = Square::from(masked);
 
             moves.moves ^= Bitboard::from(to);
@@ -234,6 +261,7 @@ pub trait Mover {
                         from: sq,
                         moves,
                         is_promotion: false,
+                        is_ep: false,
                     })
                 }
             }
@@ -248,6 +276,7 @@ pub trait Mover {
                             from: sq,
                             moves,
                             is_promotion: false,
+                            is_ep: false,
                         });
                     }
                 }

--- a/src/chess/position/san.rs
+++ b/src/chess/position/san.rs
@@ -41,14 +41,7 @@ impl Position {
     }
 
     fn is_capture(&self, mv: Move) -> Result<bool> {
-        if self.piece_at(mv.to()).is_some() {
-            return Ok(true);
-        }
-
-        let from_role = self
-            .role_at(mv.from())
-            .ok_or(ChessError::NoPieceAtSquare(mv.from()))?;
-        Ok(mv.move_type(from_role, self.ep_square) == MoveType::EnPassant)
+        Ok(mv.is_capture(self))
     }
 
     fn prefix_char(&self, mv: Move) -> Result<String> {

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -50,6 +50,7 @@ pub struct MovePicker {
     mode: MovePickerMode,
     tt_move: Move,
     killers: [Move; 2],
+    margin: i32,
 
     scored_moves: MoveList,
     scored_index: usize,
@@ -62,6 +63,7 @@ impl MovePicker {
         mode: MovePickerMode,
         tt_move: Move,
         killers: [Move; 2],
+        margin: i32,
     ) -> MovePicker {
         let mg = MoveGen::new(pos);
         MovePicker {
@@ -70,23 +72,30 @@ impl MovePicker {
             mode,
             tt_move,
             killers,
+            margin,
             scored_moves: ArrayVec::new(),
             scored_index: 0,
             sorted_index: 0,
         }
     }
 
-    pub fn new_quiescence(pos: &Position, mut tt_move: Move) -> MovePicker {
+    pub fn new_quiescence(pos: &Position, mut tt_move: Move, margin: i32) -> MovePicker {
         // If the tt move isn't a capture, we can't use it in quiescence search
         if tt_move != Move::NONE && (pos.occupancy & tt_move.to()).none() {
             tt_move = Move::NONE;
         }
 
-        MovePicker::new(pos, MovePickerMode::Quiescence, tt_move, [Move::NONE; 2])
+        MovePicker::new(
+            pos,
+            MovePickerMode::Quiescence,
+            tt_move,
+            [Move::NONE; 2],
+            margin,
+        )
     }
 
     pub fn new_ab_search(pos: &Position, tt_move: Move, killers: [Move; 2]) -> MovePicker {
-        MovePicker::new(pos, MovePickerMode::Normal, tt_move, killers)
+        MovePicker::new(pos, MovePickerMode::Normal, tt_move, killers, 1)
     }
 
     fn mvv_lva(&self, m: Move, position: &Position) -> i16 {
@@ -105,7 +114,7 @@ impl MovePicker {
             self.scored_moves[i].score = {
                 if self.scored_moves[i].m == self.tt_move {
                     TT_MOVE_SCORE as i32
-                } else if see::see(position, self.scored_moves[i].m, 1) {
+                } else if see::see(position, self.scored_moves[i].m, self.margin) {
                     self.mvv_lva(self.scored_moves[i].m, position) as i32
                         + GOOD_CAPTURE_SCORE as i32
                 } else {
@@ -171,7 +180,10 @@ impl MovePicker {
         match self.stage {
             MovePickerStage::TT => {
                 self.stage = MovePickerStage::ScoreCaptures;
-                if self.tt_move != Move::NONE {
+                if self.tt_move != Move::NONE
+                    && !(self.mode == MovePickerMode::Quiescence
+                        && self.tt_move.is_capture(position))
+                {
                     return Some(self.tt_move);
                 }
                 self.next(position, history)
@@ -196,13 +208,6 @@ impl MovePicker {
                         if m == self.tt_move {
                             return self.next(position, history);
                         }
-
-                        // in quiescence search, only return captures that are above a see
-                        // threshold
-                        if self.mode == MovePickerMode::Quiescence && !see::see(position, m, 15) {
-                            return self.next(position, history);
-                        }
-
                         Some(m)
                     }
                     None => {
@@ -242,6 +247,7 @@ impl MovePicker {
 mod tests {
     use crate::chess::movegen::init_tables;
     use crate::chess::position::fen::Fen;
+    use crate::init;
     use crate::zobrist::init_zobrist;
 
     #[test]
@@ -281,5 +287,29 @@ mod tests {
 
         // queen takes pawn and cand be recaptured
         assert_eq!(moves[5], "d4a7".parse().unwrap());
+    }
+
+    #[test]
+    fn quiescence() {
+        init();
+
+        let Fen(pos) = "2b1kbnr/5ppp/4p3/q1pP1Q1r/6P1/1NP5/PP2PP1P/R1B1KBNR w - c6 0 1"
+            .parse()
+            .unwrap();
+
+        let mut mp = super::MovePicker::new_quiescence(&pos, "e2e3".parse().unwrap(), 15);
+
+        let mut moves = Vec::new();
+        while let Some(m) = mp.next(&pos, &[[[0; 64]; 64]; 2]) {
+            moves.push(m);
+        }
+
+        // only three good captures, and because tt is a quiet move, it
+        // is not returned
+        assert_eq!(moves.len(), 3);
+
+        assert_eq!(moves[0], "b3a5".parse().unwrap()); // knight takes queen
+        assert_eq!(moves[1], "g4h5".parse().unwrap()); // pawn takes rook
+        assert_eq!(moves[2], "f5h5".parse().unwrap()); // queen takes rook
     }
 }

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -180,10 +180,7 @@ impl MovePicker {
         match self.stage {
             MovePickerStage::TT => {
                 self.stage = MovePickerStage::ScoreCaptures;
-                if self.tt_move != Move::NONE
-                    && !(self.mode == MovePickerMode::Quiescence
-                        && self.tt_move.is_capture(position))
-                {
+                if self.tt_move != Move::NONE {
                     return Some(self.tt_move);
                 }
                 self.next(position, history)

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -2,7 +2,6 @@ mod see;
 
 use arrayvec::ArrayVec;
 
-use crate::chess::bitboard::Bitboard;
 use crate::chess::movegen::MoveGen;
 use crate::chess::{Color, Move, Position, Square};
 
@@ -181,7 +180,7 @@ impl MovePicker {
                 self.stage = MovePickerStage::Captures;
                 self.scored_moves.clear();
 
-                self.move_generator.set_mask(position.occupancy);
+                self.move_generator.set_captures_only(position.occupancy);
 
                 for m in self.move_generator.by_ref() {
                     self.scored_moves.push(MoveWithScore { m, score: 0 });
@@ -217,7 +216,7 @@ impl MovePicker {
             }
             MovePickerStage::ScoreQuiets => {
                 self.stage = MovePickerStage::Quiets;
-                self.move_generator.set_mask(Bitboard::FULL);
+                self.move_generator.disable_captures_only();
 
                 for m in self.move_generator.by_ref() {
                     self.scored_moves.push(MoveWithScore { m, score: 0 });

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -100,7 +100,7 @@ impl MovePicker {
 
     fn mvv_lva(&self, m: Move, position: &Position) -> i16 {
         let attacker = position.role_at(m.from());
-        let victim = position.role_at(m.to());
+        let victim = m.captured_role(position);
 
         match (attacker, victim) {
             (None, _) => 0,
@@ -304,12 +304,14 @@ mod tests {
             moves.push(m);
         }
 
-        // only three good captures, and because tt is a quiet move, it
-        // is not returned
-        assert_eq!(moves.len(), 3);
+        // Should get 4 good captures including en passant
+        // (tt move is quiet so not returned)
+        assert_eq!(moves.len(), 4);
 
-        assert_eq!(moves[0], "b3a5".parse().unwrap()); // knight takes queen
-        assert_eq!(moves[1], "g4h5".parse().unwrap()); // pawn takes rook
-        assert_eq!(moves[2], "f5h5".parse().unwrap()); // queen takes rook
+        // Check that all expected moves are present
+        assert!(moves.contains(&"b3a5".parse().unwrap())); // knight takes queen
+        assert!(moves.contains(&"g4h5".parse().unwrap())); // pawn takes rook
+        assert!(moves.contains(&"d5c6".parse().unwrap())); // en passant capture
+        assert!(moves.contains(&"f5h5".parse().unwrap())); // queen takes rook
     }
 }

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -81,7 +81,7 @@ impl MovePicker {
 
     pub fn new_quiescence(pos: &Position, mut tt_move: Move, margin: i32) -> MovePicker {
         // If the tt move isn't a capture, we can't use it in quiescence search
-        if tt_move != Move::NONE && (pos.occupancy & tt_move.to()).none() {
+        if tt_move != Move::NONE && !tt_move.is_capture(pos) {
             tt_move = Move::NONE;
         }
 
@@ -302,13 +302,13 @@ mod tests {
         }
 
         // Should get 4 good captures including en passant
-        // (tt move is quiet so not returned)
+        // tt move is not a capture, so it should be skipped
         assert_eq!(moves.len(), 4);
 
         // Check that all expected moves are present
-        assert!(moves.contains(&"b3a5".parse().unwrap())); // knight takes queen
-        assert!(moves.contains(&"g4h5".parse().unwrap())); // pawn takes rook
-        assert!(moves.contains(&"d5c6".parse().unwrap())); // en passant capture
-        assert!(moves.contains(&"f5h5".parse().unwrap())); // queen takes rook
+        assert_eq!(moves[0], "b3a5".parse().unwrap()); // knight takes queen
+        assert_eq!(moves[1], "g4h5".parse().unwrap()); // pawn takes rook
+        assert_eq!(moves[2], "f5h5".parse().unwrap()); // queen takes rook
+        assert_eq!(moves[3], "d5c6".parse().unwrap()); // en passant capture
     }
 }

--- a/src/engine/movepicker/see.rs
+++ b/src/engine/movepicker/see.rs
@@ -43,7 +43,10 @@ pub fn see(pos: &chess::Position, mv: chess::Move, threshold: i32) -> bool {
     // "make" the move by updating the occupancy bitboard
     let mut occ = pos.occupancy ^ from | to;
     if mv.move_type(next_victim, pos.ep_square) == chess::chessmove::MoveType::EnPassant {
-        occ ^= pos.ep_square.unwrap();
+        // The captured pawn is one square behind the ep target square
+        // (in the direction of the moving pawn's starting rank)
+        let captured_pawn_sq = to.down(pos.side).unwrap();
+        occ ^= captured_pawn_sq;
     }
 
     // side is the other side, since we just made a move
@@ -224,5 +227,19 @@ mod test {
             Fen::parse("r2qkbnr/p2b1ppp/2n5/8/Q7/8/PPPPPPPP/RN2KBNR w KQkq - 0 1").unwrap();
 
         assert!(!see(&pos, "a4c6".parse().unwrap(), 0));
+    }
+
+    #[test]
+    fn en_passant() {
+        init();
+
+        let Fen(pos) =
+            Fen::parse("2b1kbnr/5ppp/4p3/q1pP1Q1r/6P1/1NP5/PP2PP1P/R1B1KBNR w - c6 0 1").unwrap();
+
+        // en passant capture is favorable
+        assert!(see(&pos, "d5c6".parse().unwrap(), 15));
+
+        // but not if the threshold is above the value of the pawn
+        assert!(!see(&pos, "d5c6".parse().unwrap(), 200));
     }
 }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -520,13 +520,8 @@ impl<'a> Search<'a> {
         let mut best = stand_pat;
         let mut best_move = Move::NONE;
 
-        // delta pruning margin
-        let margin =
-            if self.position.in_check() || self.position.non_pawn_material(self.position.side) {
-                15
-            } else {
-                500 + alpha as i32 - stand_pat as i32
-            };
+        // see margin
+        let margin = (alpha as i32 - stand_pat as i32 - 300).max(1);
 
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, margin);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -355,7 +355,7 @@ impl<'a> Search<'a> {
             MovePicker::new_ab_search(&self.position, tt_move, self.killers[ply as usize]);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
             move_count += 1;
-            let capture = (self.position.occupancy & mv.to()).any();
+            let capture = mv.is_capture(&self.position);
 
             // store node count for effort calculation
             let before_nodes = self.stats.nodes;
@@ -523,7 +523,8 @@ impl<'a> Search<'a> {
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
             // delta pruning
-            let captured = self.position.role_at(mv.to()).unwrap();
+            debug_assert!(mv.is_capture(&self.position));
+            let captured = mv.captured_role(&self.position).unwrap();
             if mv.promotion().is_none()
                 && !self.position.in_check()
                 && ((stand_pat + 500 + eval::PIECE_VALUES_EG[captured] as i16) < alpha)

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -520,11 +520,18 @@ impl<'a> Search<'a> {
         let mut best = stand_pat;
         let mut best_move = Move::NONE;
 
-        // see margin
-        let margin = (alpha as i32 - stand_pat as i32 - 300).max(1);
-
-        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, margin);
+        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, 15);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
+            // delta pruning
+            if let Some(captured) = mv.captured_role(&self.position) {
+                if mv.promotion().is_none()
+                    && !self.position.in_check()
+                    && ((stand_pat + 500 + eval::PIECE_VALUES_EG[captured] as i16) < alpha)
+                    && self.position.non_pawn_material(self.position.side)
+                {
+                    continue;
+                }
+            }
             self.position.make_move(mv);
             let score = -self.quiescence_search(-beta, -alpha, is_pv);
             self.position.unmake_move(mv);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -520,19 +520,16 @@ impl<'a> Search<'a> {
         let mut best = stand_pat;
         let mut best_move = Move::NONE;
 
-        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move);
-        while let Some(mv) = move_picker.next(&self.position, &self.history) {
-            // delta pruning
-            debug_assert!(mv.is_capture(&self.position));
-            let captured = mv.captured_role(&self.position).unwrap();
-            if mv.promotion().is_none()
-                && !self.position.in_check()
-                && ((stand_pat + 500 + eval::PIECE_VALUES_EG[captured] as i16) < alpha)
-                && self.position.non_pawn_material(self.position.side)
-            {
-                continue;
-            }
+        // delta pruning margin
+        let margin =
+            if self.position.in_check() || self.position.non_pawn_material(self.position.side) {
+                15
+            } else {
+                500 + alpha as i32 - stand_pat as i32
+            };
 
+        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, margin);
+        while let Some(mv) = move_picker.next(&self.position, &self.history) {
             self.position.make_move(mv);
             let score = -self.quiescence_search(-beta, -alpha, is_pv);
             self.position.unmake_move(mv);


### PR DESCRIPTION
Small functional change to correctly generate en passant captures during the capture movepicker stage

```
eps-in-capture-mode-no-reg [completed]
eps-in-capture-mode (h@16mb th@1) vs main (h@16mb th@1)

elo = 1.87 [-2.86, 6.50] (95%)
llr = 2.94 (accepted) | sprt = (-5.00, 0.00) [-2.94, 2.94]
wdl = 3413/5614/3325 (27.6%/45.5%/26.9%) | penta = 437/1469/2288/1533/449
games = 12352
```

https://chess.flick.ooo/workloads/01988a82-fa56-77c0-aa70-52cf851209e0