### PR TITLE
simplify and combine delta prune and see margin

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -524,7 +524,7 @@ impl<'a> Search<'a> {
         let see_margin = if self.position.non_pawn_material(self.position.side) {
             1
         } else {
-            (alpha - 250 - stand_pat).max(1) as i32
+            (alpha - 400 - stand_pat).max(1) as i32
         };
 
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -520,13 +520,7 @@ impl<'a> Search<'a> {
         let mut best = stand_pat;
         let mut best_move = Move::NONE;
 
-        // set see margin for quiescence search, I think this is equivalent to delta pruning
-        let see_margin = if self.position.non_pawn_material(self.position.side) {
-            1
-        } else {
-            (alpha - 400 - stand_pat).max(1) as i32
-        };
-
+        let see_margin = (alpha - 500 - stand_pat).max(1) as i32;
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
             self.position.make_move(mv);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -520,18 +520,15 @@ impl<'a> Search<'a> {
         let mut best = stand_pat;
         let mut best_move = Move::NONE;
 
-        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, 15);
+        // set see margin for quiescence search, I think this is equivalent to delta pruning
+        let see_margin = if self.position.non_pawn_material(self.position.side) {
+            1
+        } else {
+            (alpha - 250 - stand_pat).max(1) as i32
+        };
+
+        let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
-            // delta pruning
-            if let Some(captured) = mv.captured_role(&self.position) {
-                if mv.promotion().is_none()
-                    && !self.position.in_check()
-                    && ((stand_pat + 500 + eval::PIECE_VALUES_EG[captured] as i16) < alpha)
-                    && self.position.non_pawn_material(self.position.side)
-                {
-                    continue;
-                }
-            }
             self.position.make_move(mv);
             let score = -self.quiescence_search(-beta, -alpha, is_pv);
             self.position.unmake_move(mv);


### PR DESCRIPTION
```
simplify-pruning [completed]
simple-delta-prune (h@16mb th@1) vs main (h@16mb th@1)

elo = 2.56 [-2.44, 7.49] (95%)
llr = 2.94 (accepted) | sprt = (-5.00, 0.00) [-2.94, 2.94]
wdl = 2732/4962/2638 (26.4%/48.0%/25.5%) | penta = 327/1273/1900/1311/355
games = 10332
```
https://chess.flick.ooo/workloads/01988b31-56c4-7e07-b914-16318c82261e