### PR TITLE
fix: datagen format bug and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pounce"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pounce"
 authors = ["alex flick"]
 edition = "2024"
-version = "2.0.1"
+version = "2.0.2"
 build = "build.rs"
 default-run = "pounce"
 repository = "https://github.com/0xflick/pounce"

--- a/src/datagen/format.rs
+++ b/src/datagen/format.rs
@@ -352,7 +352,7 @@ impl Iterator for PositionIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         // we skip the last move because it is the final position
-        if self.index >= self.game.moves.len() - 1 {
+        if self.index >= self.game.moves.len().saturating_sub(1) {
             return None;
         }
 


### PR DESCRIPTION
Fix bug in reading a datagen binary (though there's still a question about why we're pushing a position with no moves?)
