### PR TITLE
feat: use tt eval and static score more carefully

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -550,16 +550,12 @@ impl<'a> Search<'a> {
 
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
-        } else if let Some(Entry {
-            static_eval: tt_static_eval,
-            ..
-        }) = tt_hit
-        {
-            stand_pat = if tt_static_eval != eval::NO_VALUE {
-                tt_static_eval
+        } else if let Some(entry) = tt_hit {
+            if entry.static_eval != eval::NO_VALUE {
+                stand_pat = denormalize_score(entry.static_eval, MAX_PLY);
             } else {
-                eval::score_nnue(&self.position, &self.accum)
-            };
+                stand_pat = eval::score_nnue(&self.position, &self.accum);
+            }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
         }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -602,7 +602,7 @@ impl<'a> Search<'a> {
                 value
             };
 
-            let delta_margin = alpha.saturating_sub(stand_pat).saturating_sub(200) as i32;
+            let delta_margin = alpha.saturating_sub(stand_pat).saturating_sub(425) as i32;
             if best_case_score < delta_margin {
                 return stand_pat;
             }
@@ -610,7 +610,7 @@ impl<'a> Search<'a> {
 
         let tt_move = tt_hit.map_or(Move::NONE, |tt| tt.best_move);
 
-        let see_margin = alpha.saturating_sub(stand_pat).saturating_sub(200).max(1) as i32;
+        let see_margin = alpha.saturating_sub(stand_pat).saturating_sub(500).max(1) as i32;
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
             self.position.make_move_with(mv, &mut self.accum);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -551,11 +551,20 @@ impl<'a> Search<'a> {
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
         } else if let Some(entry) = tt_hit {
-            if entry.static_eval != eval::NO_VALUE {
-                stand_pat = denormalize_score(entry.static_eval, MAX_PLY);
+            let eval = if entry.static_eval != eval::NO_VALUE {
+                denormalize_score(entry.static_eval, MAX_PLY)
             } else {
-                stand_pat = eval::score_nnue(&self.position, &self.accum);
-            }
+                eval::score_nnue(&self.position, &self.accum)
+            };
+
+            let denormalized_score = denormalize_score(entry.score, MAX_PLY);
+
+            stand_pat = match entry.score_type {
+                EntryType::Exact => entry.score,
+                EntryType::LowerBound if denormalized_score > eval => denormalized_score,
+                EntryType::UpperBound if denormalized_score < eval => denormalized_score,
+                _ => eval,
+            };
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
         }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -560,7 +560,7 @@ impl<'a> Search<'a> {
             let denormalized_score = denormalize_score(entry.score, MAX_PLY);
 
             stand_pat = match entry.score_type {
-                EntryType::Exact => entry.score,
+                EntryType::Exact => denormalized_score,
                 EntryType::LowerBound if denormalized_score > eval => denormalized_score,
                 EntryType::UpperBound if denormalized_score < eval => denormalized_score,
                 _ => eval,

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -298,16 +298,22 @@ impl<'a> Search<'a> {
         } else if let Some(Entry {
             score: tt_score,
             static_eval: tt_static_eval,
+            score_type,
             ..
-        }) = &tt_hit
+        }) = tt_hit
         {
-            if *tt_score != eval::NO_VALUE {
-                static_eval = denormalize_score(*tt_score, ply);
-            } else if *tt_static_eval != eval::NO_VALUE {
-                static_eval = *tt_static_eval;
+            let eval = if tt_static_eval != eval::NO_VALUE {
+                denormalize_score(tt_score, ply)
             } else {
-                static_eval = eval::score_nnue(&self.position, &self.accum);
-            }
+                eval::score_nnue(&self.position, &self.accum)
+            };
+
+            static_eval = match score_type {
+                EntryType::Exact => tt_score,
+                EntryType::LowerBound if tt_score > eval => denormalize_score(tt_score, ply),
+                EntryType::UpperBound if tt_score < eval => denormalize_score(tt_score, ply),
+                _ => eval,
+            };
         } else {
             static_eval = eval::score_nnue(&self.position, &self.accum);
 
@@ -316,7 +322,7 @@ impl<'a> Search<'a> {
                 depth as u8,
                 static_eval,
                 static_eval,
-                EntryType::Exact,
+                EntryType::None,
                 Move::NONE,
             ));
         }
@@ -547,10 +553,10 @@ impl<'a> Search<'a> {
         } else if let Some(Entry {
             static_eval: tt_static_eval,
             ..
-        }) = &tt_hit
+        }) = tt_hit
         {
-            stand_pat = if *tt_static_eval != eval::NO_VALUE {
-                *tt_static_eval
+            stand_pat = if tt_static_eval != eval::NO_VALUE {
+                tt_static_eval
             } else {
                 eval::score_nnue(&self.position, &self.accum)
             };
@@ -635,16 +641,10 @@ impl<'a> Search<'a> {
         };
 
         if !self.stop.load(std::sync::atomic::Ordering::Relaxed) {
-            let static_eval = if stand_pat == -eval::INFINITY {
-                eval::NO_VALUE
-            } else {
-                stand_pat
-            };
-
             self.tt.store(Entry::new(
                 self.position.key,
                 0,
-                static_eval,
+                stand_pat,
                 normalize_score(best, MAX_PLY),
                 entry_type,
                 best_move,

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -308,10 +308,12 @@ impl<'a> Search<'a> {
                 eval::score_nnue(&self.position, &self.accum)
             };
 
+            let denormalized_score = denormalize_score(tt_score, ply);
+
             static_eval = match score_type {
-                EntryType::Exact => tt_score,
-                EntryType::LowerBound if tt_score > eval => denormalize_score(tt_score, ply),
-                EntryType::UpperBound if tt_score < eval => denormalize_score(tt_score, ply),
+                EntryType::Exact => denormalized_score,
+                EntryType::LowerBound if denormalized_score > eval => denormalized_score,
+                EntryType::UpperBound if denormalized_score < eval => denormalized_score,
                 _ => eval,
             };
         } else {
@@ -550,16 +552,22 @@ impl<'a> Search<'a> {
 
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
-        } else if let Some(entry) = tt_hit {
-            let eval = if entry.static_eval != eval::NO_VALUE {
-                denormalize_score(entry.static_eval, MAX_PLY)
+        } else if let Some(Entry {
+            score: tt_score,
+            static_eval: tt_static_eval,
+            score_type,
+            ..
+        }) = tt_hit
+        {
+            let eval = if tt_static_eval != eval::NO_VALUE {
+                denormalize_score(tt_static_eval, MAX_PLY)
             } else {
                 eval::score_nnue(&self.position, &self.accum)
             };
 
-            let denormalized_score = denormalize_score(entry.score, MAX_PLY);
+            let denormalized_score = denormalize_score(tt_score, MAX_PLY);
 
-            stand_pat = match entry.score_type {
+            stand_pat = match score_type {
                 EntryType::Exact => denormalized_score,
                 EntryType::LowerBound if denormalized_score > eval => denormalized_score,
                 EntryType::UpperBound if denormalized_score < eval => denormalized_score,
@@ -567,6 +575,15 @@ impl<'a> Search<'a> {
             };
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
+
+            self.tt.store(Entry::new(
+                self.position.key,
+                0,
+                stand_pat,
+                stand_pat,
+                EntryType::None,
+                Move::NONE,
+            ));
         }
 
         if stand_pat >= beta {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -547,15 +547,21 @@ impl<'a> Search<'a> {
         } else if let Some(Entry {
             score: tt_score,
             static_eval: tt_static_eval,
+            score_type,
             ..
         }) = &tt_hit
         {
-            if *tt_score != eval::NO_VALUE {
-                stand_pat = denormalize_score(*tt_score, MAX_PLY);
-            } else if *tt_static_eval != eval::NO_VALUE {
-                stand_pat = *tt_static_eval;
+            let static_eval = if *tt_static_eval != eval::NO_VALUE {
+                *tt_static_eval
             } else {
-                stand_pat = eval::score_nnue(&self.position, &self.accum);
+                eval::score_nnue(&self.position, &self.accum)
+            };
+
+            stand_pat = match score_type {
+                EntryType::Exact => *tt_score,
+                EntryType::LowerBound if *tt_score > static_eval => *tt_score,
+                EntryType::UpperBound if *tt_score < static_eval => *tt_score,
+                _ => static_eval,
             }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -545,13 +545,24 @@ impl<'a> Search<'a> {
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
         } else if let Some(entry) = tt_hit {
-            if entry.static_eval != eval::NO_VALUE {
-                stand_pat = denormalize_score(entry.static_eval, MAX_PLY);
+            if entry.score != eval::NO_VALUE {
+                stand_pat = denormalize_score(entry.score, MAX_PLY);
+            } else if entry.static_eval != eval::NO_VALUE {
+                stand_pat = entry.static_eval;
             } else {
                 stand_pat = eval::score_nnue(&self.position, &self.accum);
             }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
+
+            self.tt.store(Entry::new(
+                self.position.key,
+                0,
+                stand_pat,
+                stand_pat,
+                EntryType::Exact,
+                Move::NONE,
+            ));
         }
 
         if stand_pat >= beta {
@@ -591,7 +602,7 @@ impl<'a> Search<'a> {
                 value
             };
 
-            let delta_margin = alpha.saturating_sub(stand_pat).saturating_sub(425) as i32;
+            let delta_margin = alpha.saturating_sub(stand_pat).saturating_sub(200) as i32;
             if best_case_score < delta_margin {
                 return stand_pat;
             }
@@ -599,7 +610,7 @@ impl<'a> Search<'a> {
 
         let tt_move = tt_hit.map_or(Move::NONE, |tt| tt.best_move);
 
-        let see_margin = alpha.saturating_sub(stand_pat).saturating_sub(500).max(1) as i32;
+        let see_margin = alpha.saturating_sub(stand_pat).saturating_sub(200).max(1) as i32;
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);
         while let Some(mv) = move_picker.next(&self.position, &self.history) {
             self.position.make_move_with(mv, &mut self.accum);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -306,7 +306,7 @@ impl<'a> Search<'a> {
             } else if *tt_static_eval != eval::NO_VALUE {
                 static_eval = *tt_static_eval;
             } else {
-                static_eval = eval::NO_VALUE;
+                static_eval = eval::score_nnue(&self.position, &self.accum);
             }
         } else {
             static_eval = eval::score_nnue(&self.position, &self.accum);
@@ -555,7 +555,7 @@ impl<'a> Search<'a> {
             } else if *tt_static_eval != eval::NO_VALUE {
                 stand_pat = *tt_static_eval;
             } else {
-                stand_pat = eval::NO_VALUE;
+                stand_pat = eval::score_nnue(&self.position, &self.accum);
             }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -559,15 +559,6 @@ impl<'a> Search<'a> {
             }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
-
-            self.tt.store(Entry::new(
-                self.position.key,
-                0,
-                stand_pat,
-                stand_pat,
-                EntryType::Exact,
-                Move::NONE,
-            ));
         }
 
         if stand_pat >= beta {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -544,13 +544,18 @@ impl<'a> Search<'a> {
 
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
-        } else if let Some(entry) = tt_hit {
-            if entry.score != eval::NO_VALUE {
-                stand_pat = denormalize_score(entry.score, MAX_PLY);
-            } else if entry.static_eval != eval::NO_VALUE {
-                stand_pat = entry.static_eval;
+        } else if let Some(Entry {
+            score: tt_score,
+            static_eval: tt_static_eval,
+            ..
+        }) = &tt_hit
+        {
+            if *tt_score != eval::NO_VALUE {
+                stand_pat = denormalize_score(*tt_score, MAX_PLY);
+            } else if *tt_static_eval != eval::NO_VALUE {
+                stand_pat = *tt_static_eval;
             } else {
-                stand_pat = eval::score_nnue(&self.position, &self.accum);
+                stand_pat = eval::NO_VALUE;
             }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
@@ -642,10 +647,16 @@ impl<'a> Search<'a> {
         };
 
         if !self.stop.load(std::sync::atomic::Ordering::Relaxed) {
+            let static_eval = if stand_pat == -eval::INFINITY {
+                eval::NO_VALUE
+            } else {
+                stand_pat
+            };
+
             self.tt.store(Entry::new(
                 self.position.key,
                 0,
-                stand_pat,
+                static_eval,
                 normalize_score(best, MAX_PLY),
                 entry_type,
                 best_move,

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -545,24 +545,15 @@ impl<'a> Search<'a> {
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
         } else if let Some(Entry {
-            score: tt_score,
             static_eval: tt_static_eval,
-            score_type,
             ..
         }) = &tt_hit
         {
-            let static_eval = if *tt_static_eval != eval::NO_VALUE {
+            stand_pat = if *tt_static_eval != eval::NO_VALUE {
                 *tt_static_eval
             } else {
                 eval::score_nnue(&self.position, &self.accum)
             };
-
-            stand_pat = match score_type {
-                EntryType::Exact => *tt_score,
-                EntryType::LowerBound if *tt_score > static_eval => *tt_score,
-                EntryType::UpperBound if *tt_score < static_eval => *tt_score,
-                _ => static_eval,
-            }
         } else {
             stand_pat = eval::score_nnue(&self.position, &self.accum);
         }


### PR DESCRIPTION
```
qse [completed]
qsearch-eval (h@16mb th@1) vs main (h@16mb th@1)

elo = 4.34 [0.28, 8.28] (95%)
llr = 2.94 (accepted) | sprt = (0.00, 5.00) [-2.94, 2.94]
wdl = 4239/7765/4012 (26.5%/48.5%/25.0%) | penta = 498/1883/3067/2014/546
games = 16016
```