### PR TITLE
countermove

### DIFF
--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -4,7 +4,7 @@ use arrayvec::ArrayVec;
 
 use crate::chess::movegen::MoveGen;
 use crate::chess::{Color, Move, Position, Role, Square};
-use crate::engine::search::{Search, MAX_PLY};
+use crate::engine::search::{MAX_PLY, Search};
 
 const TT_MOVE_SCORE: i16 = 30_000;
 const GOOD_TACTICAL_SCORE: i16 = 22_000;

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -112,7 +112,8 @@ pub struct Search<'a> {
 
     pub current_move: [(Move, Option<Role>); MAX_PLY as usize],
     pub history: [[[i16; Square::NUM]; Square::NUM]; Color::NUM],
-    pub continuation: Box<[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM]>,
+    pub continuation:
+        Box<[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM]>,
     killers: [[Move; 2]; MAX_PLY as usize],
     eval: [i16; MAX_PLY as usize],
     tt: &'a Table,
@@ -142,7 +143,9 @@ impl<'a> Search<'a> {
             accum,
             current_move: [(Move::NONE, None); MAX_PLY as usize],
             history: [[[0; Square::NUM]; Square::NUM]; Color::NUM],
-            continuation: Box::new([[[[[0; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM]),
+            continuation: Box::new(
+                [[[[[0; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM],
+            ),
             killers: [[Move::NONE; 2]; MAX_PLY as usize],
             eval: [eval::NO_VALUE; MAX_PLY as usize],
             tm: SearchCop::new(limits, side),


### PR DESCRIPTION
```
countermove [completed]
countermove (h@16mb th@1) vs main (h@16mb th@1)

elo = 10.23 [1.53, 18.81] (95%)
llr = 2.94 (accepted) | sprt = (0.00, 10.00) [-2.94, 2.94]
wdl = 732/1638/634 (24.4%/54.5%/21.1%) | penta = 71/322/628/400/81
games = 3004
```