### PR TITLE
refactor: improve history tables

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,7 +109,7 @@ fn days_to_date(days: u64) -> (u64, u64, u64) {
 }
 
 fn is_leap_year(year: u64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || (year.is_multiple_of(400))
 }
 
 fn run_git_command(args: &[&str]) -> Option<String> {

--- a/src/datagen/format.rs
+++ b/src/datagen/format.rs
@@ -87,57 +87,6 @@ impl CompressedPosition {
         }
     }
 
-    pub fn flip(&self) -> Self {
-        let mut mailbox: [Option<Piece>; 64] = [None; 64];
-
-        for (idx, sq) in self.occ.enumerate() {
-            let pc = self.pieces.get(idx);
-
-            let color = if pc >> 3 == 0 {
-                Color::White
-            } else {
-                Color::Black
-            };
-
-            mailbox[(sq) as usize] = Some(Piece {
-                color,
-                role: unsafe { std::mem::transmute::<u8, Role>(pc & 0b111) },
-            });
-        }
-
-        let occ = self.occ.flip();
-        let mut pieces = U4Array32::default();
-        for (idx, sq) in occ.enumerate() {
-            let pc = mailbox[sq ^ 56].unwrap();
-            let bit_pc = ((1 - pc.color as u8) << 3) | (pc.role as u8);
-
-            pieces.set(idx, bit_pc);
-        }
-
-        let ep_square = if self.stm_ep_square == u8::MAX {
-            u8::MAX
-        } else {
-            self.stm_ep_square ^ 56
-        };
-
-        let new_ply = if self.ply % 2 == 0 {
-            self.ply + 1
-        } else {
-            self.ply - 1
-        };
-
-        Self {
-            occ,
-            pieces,
-            score: -self.score,
-            wdl: self.wdl.flip(),
-            stm_ep_square: ep_square,
-            halfmove_clock: self.halfmove_clock,
-            ply: new_ply,
-            castling: self.castling,
-        }
-    }
-
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
             std::slice::from_raw_parts(self as *const _ as *const u8, std::mem::size_of::<Self>())
@@ -272,7 +221,7 @@ impl TryFrom<CompressedPosition> for Position {
             sq => Some(Square::from(sq)),
         };
         pos.halfmove_clock = value.halfmove_clock;
-        pos.side = if value.ply % 2 == 0 {
+        pos.side = if value.ply.is_multiple_of(2) {
             Color::White
         } else {
             Color::Black
@@ -382,38 +331,10 @@ impl Iterator for PositionIterator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chess::position::fen::{Fen, STARTPOS};
 
     #[test]
     fn test_size() {
         assert_eq!(std::mem::size_of::<CompressedPosition>(), 32);
         assert_eq!(std::mem::size_of::<CompressedMove>(), 4);
-    }
-
-    #[test]
-    fn test_startpos() {
-        let Fen(pos) = Fen::parse(STARTPOS).unwrap();
-
-        let comp = CompressedPosition::new(&pos, 0, Wdl::BlackWin);
-
-        assert_eq!(comp, comp.flip().flip());
-
-        assert_eq!(comp.occ, comp.flip().occ);
-        assert_eq!(comp.pieces, comp.flip().pieces);
-        assert_eq!(comp.score, -comp.flip().score);
-    }
-
-    const POS_1: &str = "b3r1k1/5pbp/6p1/1NP5/8/5N2/2Q3PP/3q2K1 b - - 0 31";
-    const POS_1_FLIPPED: &str = "3Q2k1/2q3pp/5n2/8/1np5/6P1/5PBP/B3R1K1 w - - 0 31";
-
-    #[test]
-    fn test_flip() {
-        let Fen(pos) = Fen::parse(POS_1).unwrap();
-        let comp = CompressedPosition::new(&pos, 600, Wdl::BlackWin);
-
-        let Fen(flip) = POS_1_FLIPPED.parse().unwrap();
-        let comp_flip = CompressedPosition::new(&flip, -600, Wdl::WhiteWin);
-
-        assert_eq!(comp_flip, comp.flip());
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,6 +5,7 @@ pub mod search;
 pub mod tt;
 pub mod uci;
 
+mod history;
 mod movepicker;
 mod search_manager;
 mod time_management;

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -79,6 +79,10 @@ impl HistoryTables {
         value
     }
 
+    pub fn is_killer(&self, ply: usize, mv: Move) -> bool {
+        mv == self.killers[ply][0] || mv == self.killers[ply][1]
+    }
+
     fn history_index(&self, position: &Position, mv: Move) -> (Color, Square, Square) {
         (position.side, mv.from(), mv.to())
     }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -1,11 +1,8 @@
-use crate::{
-    chess::{Color, Move, Position, Role, Square},
-    engine::{
-        movepicker::{KILLER_1_SCORE, KILLER_2_SCORE},
-        search::{Frame, MAX_PLY, Stack},
-    },
-};
 use std::ops::ShlAssign;
+
+use crate::chess::{Color, Move, Position, Role, Square};
+use crate::engine::movepicker::{KILLER_1_SCORE, KILLER_2_SCORE};
+use crate::engine::search::{Frame, MAX_PLY, Stack};
 
 pub const HISTORY_MAX: i32 = i16::MAX as i32;
 

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -67,7 +67,7 @@ impl HistoryTables {
         }
         let mut value = 0;
         let hist_idx = self.history_index(position, mv);
-        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32 / 2;
+        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].0 as i32 / 2;
 
         for i in 1..=self.continuation.len() {
             if ply < i {
@@ -75,7 +75,7 @@ impl HistoryTables {
             }
 
             if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
-                value += self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].value
+                value += self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].0
                     as i32
                     / 2;
             }
@@ -113,18 +113,16 @@ impl HistoryTables {
 }
 
 #[derive(Default, Clone, Copy)]
-struct HistScore<T: Default, const MAX: i32> {
-    value: T,
-}
+struct HistScore<T: Default, const MAX: i32>(T);
 
 impl<const MAX: i32> ShlAssign<i32> for HistScore<i16, MAX> {
     fn shl_assign(&mut self, rhs: i32) {
-        self.value += (rhs - (self.value as i32) * rhs.abs() / MAX) as i16;
+        self.0 += (rhs - (self.0 as i32) * rhs.abs() / MAX) as i16;
     }
 }
 
 impl<const MAX: i32> ShlAssign<i32> for HistScore<i32, MAX> {
     fn shl_assign(&mut self, rhs: i32) {
-        self.value += rhs - self.value * rhs.abs() / MAX;
+        self.0 += rhs - self.0 * rhs.abs() / MAX;
     }
 }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -1,10 +1,13 @@
 use crate::{
     chess::{Color, Move, Position, Role, Square},
-    engine::search::{Frame, Stack},
+    engine::{
+        movepicker::{KILLER_1_SCORE, KILLER_2_SCORE},
+        search::{Frame, MAX_PLY, Stack},
+    },
 };
 use std::ops::ShlAssign;
 
-const HISTORY_MAX: i32 = i16::MAX as i32;
+pub const HISTORY_MAX: i32 = i16::MAX as i32;
 
 type Sided<T> = [T; Color::NUM];
 type Butterfly<T> = [[T; Square::NUM]; Square::NUM];
@@ -13,6 +16,7 @@ type HistoryTable<T, const MAX: i32> = Sided<Butterfly<HistScore<T, MAX>>>;
 type ContinuationTable<T, const MAX: i32> = Sided<RoleTo<RoleTo<HistScore<T, MAX>>>>;
 
 pub struct HistoryTables {
+    killers: [[Move; 2]; MAX_PLY],
     history: HistoryTable<i16, HISTORY_MAX>,
     continuation: Box<[ContinuationTable<i16, HISTORY_MAX>; 1]>,
 }
@@ -28,6 +32,7 @@ impl Default for HistoryTables {
         };
 
         Self {
+            killers: [[Move::NONE; 2]; MAX_PLY],
             history: [[[HistScore::<i16, HISTORY_MAX>::default(); Square::NUM]; Square::NUM];
                 Color::NUM],
             continuation,
@@ -47,8 +52,18 @@ impl HistoryTables {
         }
     }
 
+    pub fn update_killers(&mut self, mv: Move, ply: usize) {
+        self.killers[ply][1] = self.killers[ply][0];
+        self.killers[ply][0] = mv;
+    }
+
     pub fn score(&self, position: &Position, stack: &Stack, ply: usize, mv: Move) -> i32 {
         let mut value = 0;
+        if mv == self.killers[ply][0] {
+            return KILLER_1_SCORE;
+        } else if mv == self.killers[ply][1] {
+            return KILLER_2_SCORE;
+        }
 
         let hist_idx = self.history_index(position, mv);
         value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32;

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -1,44 +1,109 @@
-use crate::chess::{Color, Square};
+use crate::{
+    chess::{Color, Move, Position, Role, Square},
+    engine::search::{Frame, Stack},
+};
+use std::ops::ShlAssign;
 
 const HISTORY_MAX: i32 = i16::MAX as i32;
 
-pub struct History([[[i32; Square::NUM]; Square::NUM]; Color::NUM]);
+type Sided<T> = [T; Color::NUM];
+type Butterfly<T> = [[T; Square::NUM]; Square::NUM];
+type RoleTo<T> = [[T; Square::NUM]; Role::NUM];
+type HistoryTable<T, const MAX: i32> = Sided<Butterfly<HistScore<T, MAX>>>;
+type ContinuationTable<T, const MAX: i32> = Sided<RoleTo<RoleTo<HistScore<T, MAX>>>>;
 
-impl Default for History {
+pub struct HistoryTables {
+    history: HistoryTable<i16, HISTORY_MAX>,
+    continuation: Box<[ContinuationTable<i16, HISTORY_MAX>; 1]>,
+}
+
+impl Default for HistoryTables {
     fn default() -> Self {
-        Self([[[0; Square::NUM]; Square::NUM]; Color::NUM])
+        // this is janky but without this rust tries to initialize the array, *and then* put it
+        // into the box, which blows up the stack on debug builds
+        let mut boxed = Box::<[ContinuationTable<i16, HISTORY_MAX>; 1]>::new_uninit();
+        let continuation = unsafe {
+            boxed.as_mut_ptr().write_bytes(0u8, 1);
+            boxed.assume_init()
+        };
+
+        Self {
+            history: [[[HistScore::<i16, HISTORY_MAX>::default(); Square::NUM]; Square::NUM];
+                Color::NUM],
+            continuation,
+        }
     }
 }
 
-impl History {
-    pub fn update(&mut self, side: Color, from: Square, to: Square, bonus: i32) {
-        let index = &mut self.0[side][from][to];
-        taper_update::<HISTORY_MAX>(index, bonus);
+impl HistoryTables {
+    pub fn update(&mut self, position: &Position, stack: &Stack, ply: usize, mv: Move, bonus: i32) {
+        let hist_idx = self.history_index(position, mv);
+        self.history[hist_idx.0][hist_idx.1][hist_idx.2] <<= bonus;
+
+        for i in 0..self.continuation.len() {
+            if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
+                self.continuation[i][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4] <<= bonus;
+            }
+        }
     }
 
-    pub fn score(&self, side: Color, from: Square, to: Square) -> i32 {
-        self.0[side][from][to]
+    pub fn score(&self, position: &Position, stack: &Stack, ply: usize, mv: Move) -> i32 {
+        let mut value = 0;
+
+        let hist_idx = self.history_index(position, mv);
+        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32;
+
+        for i in 1..=self.continuation.len() {
+            if ply < i {
+                break;
+            }
+
+            if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
+                value += self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].value
+                    as i32;
+            }
+        }
+
+        value
+    }
+
+    fn history_index(&self, position: &Position, mv: Move) -> (Color, Square, Square) {
+        (position.side, mv.from(), mv.to())
+    }
+
+    fn continuation_index(
+        &self,
+        position: &Position,
+        frame: &Frame,
+        mv: Move,
+    ) -> Option<(Color, Role, Square, Role, Square)> {
+        match frame.moved {
+            Some(prev_role) => {
+                let prev_to = frame.mv.to();
+
+                let role = position.role_at(mv.from()).expect("No role at position");
+
+                Some((position.side, prev_role, prev_to, role, mv.to()))
+            }
+            // Null move
+            None => None,
+        }
     }
 }
 
-fn taper_update<const MAX: i32>(index: &mut i32, bonus: i32) {
-    *index += bonus - (*index * bonus.abs() / MAX);
+#[derive(Default, Clone, Copy)]
+struct HistScore<T: Default, const MAX: i32> {
+    value: T,
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
+impl<const MAX: i32> ShlAssign<i32> for HistScore<i16, MAX> {
+    fn shl_assign(&mut self, rhs: i32) {
+        self.value += (rhs - (self.value as i32) * rhs.abs() / MAX) as i16;
+    }
+}
 
-    #[test]
-    fn test_taper() {
-        let mut history = History::default();
-
-        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 0);
-        history.update(Color::White, Square::A1, Square::A1, 1000);
-
-        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 1000);
-
-        history.update(Color::White, Square::A1, Square::A1, 1000);
-        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 1970);
+impl<const MAX: i32> ShlAssign<i32> for HistScore<i32, MAX> {
+    fn shl_assign(&mut self, rhs: i32) {
+        self.value += rhs - self.value * rhs.abs() / MAX;
     }
 }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -63,7 +63,7 @@ impl HistoryTables {
         }
 
         let hist_idx = self.history_index(position, mv);
-        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32;
+        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32 / 2;
 
         for i in 1..=self.continuation.len() {
             if ply < i {
@@ -72,7 +72,8 @@ impl HistoryTables {
 
             if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
                 value += self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].value
-                    as i32;
+                    as i32
+                    / 2;
             }
         }
 

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -4,7 +4,7 @@ use crate::chess::{Color, Move, Position, Role, Square};
 use crate::engine::movepicker::{KILLER_1_SCORE, KILLER_2_SCORE};
 use crate::engine::search::{Frame, MAX_PLY, Stack};
 
-pub const HISTORY_MAX: i32 = i16::MAX as i32;
+pub const HISTORY_MAX: i32 = 16384;
 
 type Sided<T> = [T; Color::NUM];
 type Butterfly<T> = [[T; Square::NUM]; Square::NUM];
@@ -58,13 +58,14 @@ impl HistoryTables {
     }
 
     pub fn score(&self, position: &Position, stack: &Stack, ply: usize, mv: Move) -> i32 {
-        let mut value = 0;
-        if mv == self.killers[ply][0] {
-            return KILLER_1_SCORE;
-        } else if mv == self.killers[ply][1] {
-            return KILLER_2_SCORE;
+        if ply != MAX_PLY {
+            if mv == self.killers[ply][0] {
+                return KILLER_1_SCORE;
+            } else if mv == self.killers[ply][1] {
+                return KILLER_2_SCORE;
+            }
         }
-
+        let mut value = 0;
         let hist_idx = self.history_index(position, mv);
         value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].value as i32 / 2;
 

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -47,7 +47,7 @@ impl HistoryTables {
                 break;
             }
             if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
-                self.continuation[i][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4] <<= bonus;
+                self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4] <<= bonus;
             }
         }
     }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -42,7 +42,10 @@ impl HistoryTables {
         let hist_idx = self.history_index(position, mv);
         self.history[hist_idx.0][hist_idx.1][hist_idx.2] <<= bonus;
 
-        for i in 0..self.continuation.len() {
+        for i in 1..=self.continuation.len() {
+            if ply < i {
+                break;
+            }
             if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
                 self.continuation[i][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4] <<= bonus;
             }

--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -1,0 +1,44 @@
+use crate::chess::{Color, Square};
+
+const HISTORY_MAX: i32 = i16::MAX as i32;
+
+pub struct History([[[i32; Square::NUM]; Square::NUM]; Color::NUM]);
+
+impl Default for History {
+    fn default() -> Self {
+        Self([[[0; Square::NUM]; Square::NUM]; Color::NUM])
+    }
+}
+
+impl History {
+    pub fn update(&mut self, side: Color, from: Square, to: Square, bonus: i32) {
+        let index = &mut self.0[side][from][to];
+        taper_update::<HISTORY_MAX>(index, bonus);
+    }
+
+    pub fn score(&self, side: Color, from: Square, to: Square) -> i32 {
+        self.0[side][from][to]
+    }
+}
+
+fn taper_update<const MAX: i32>(index: &mut i32, bonus: i32) {
+    *index += bonus - (*index * bonus.abs() / MAX);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_taper() {
+        let mut history = History::default();
+
+        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 0);
+        history.update(Color::White, Square::A1, Square::A1, 1000);
+
+        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 1000);
+
+        history.update(Color::White, Square::A1, Square::A1, 1000);
+        assert_eq!(history.score(Color::White, Square::A1, Square::A1), 1970);
+    }
+}

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -8,11 +8,11 @@ use crate::engine::history::{HISTORY_MAX, HistoryTables};
 use crate::engine::search::{MAX_PLY, Search, Stack};
 
 const TT_MOVE_SCORE: i32 = 30_000;
-const GOOD_TACTICAL_SCORE: i32 = 22_000 + HISTORY_MAX * 2;
-const QUEEN_PROMO_BONUS: i32 = 21_002 + HISTORY_MAX * 2;
-pub const KILLER_1_SCORE: i32 = 21_001 + HISTORY_MAX * 2;
-pub const KILLER_2_SCORE: i32 = 21_000 + HISTORY_MAX * 2;
-const BAD_TACTICAL_SCORE: i32 = 17_000 + HISTORY_MAX * 2;
+const GOOD_TACTICAL_SCORE: i32 = 22_000;
+const QUEEN_PROMO_BONUS: i32 = 21_002;
+pub const KILLER_1_SCORE: i32 = 21_001;
+pub const KILLER_2_SCORE: i32 = 21_000;
+const BAD_TACTICAL_SCORE: i32 = 17_000;
 
 pub const MAX_MOVES: usize = 256;
 
@@ -141,9 +141,14 @@ impl MovePicker {
     }
 
     fn score_quiets(&mut self, history: &HistoryTables, position: &Position, stack: &Stack) {
+        let ply = if self.mode == MovePickerMode::QuiescenceCheck {
+            MAX_PLY
+        } else {
+            self.ply
+        };
         for i in self.scored_index..self.scored_moves.len() {
             let m = self.scored_moves[i].m;
-            self.scored_moves[i].score = history.score(position, stack, self.ply, m);
+            self.scored_moves[i].score = history.score(position, stack, ply, m);
         }
         self.scored_index = self.scored_moves.len();
     }
@@ -224,11 +229,6 @@ impl MovePicker {
 
                 for m in self.move_generator.by_ref() {
                     self.scored_moves.push(MoveWithScore { m, score: 0 });
-                }
-
-                if self.mode == MovePickerMode::QuiescenceCheck {
-                    // sortin moves doesn't matter when we're in check in quiescence
-                    return self.next(search);
                 }
 
                 self.score_quiets(&search.history, &search.position, &search.stack);

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -4,6 +4,7 @@ use arrayvec::ArrayVec;
 
 use crate::chess::movegen::MoveGen;
 use crate::chess::{Color, Move, Position, Role, Square};
+use crate::engine::history::History;
 use crate::engine::search::{MAX_PLY, Search};
 
 const TT_MOVE_SCORE: i16 = 30_000;
@@ -143,7 +144,7 @@ impl MovePicker {
     fn score_quiets(
         &mut self,
         position: &Position,
-        history: &[[[i16; Square::NUM]; Square::NUM]; Color::NUM],
+        history: &History,
         continuation: &[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM],
         ply: u8,
         current_move: &[(Move, Option<Role>); MAX_PLY as usize],
@@ -155,7 +156,7 @@ impl MovePicker {
             } else if m == self.killers[1] {
                 self.scored_moves[i].score = KILLER_2_SCORE as i32;
             } else {
-                let history_bonus = history[position.side][m.from()][m.to()] as i32;
+                let history_bonus = history.score(position.side, m.from(), m.to());
                 let counter_move_bonus = if ply == 0 || ply == MAX_PLY {
                     0
                 } else {

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -4,7 +4,7 @@ use arrayvec::ArrayVec;
 
 use crate::chess::movegen::MoveGen;
 use crate::chess::{Move, Position, Role};
-use crate::engine::history::{HISTORY_MAX, HistoryTables};
+use crate::engine::history::HistoryTables;
 use crate::engine::search::{MAX_PLY, Search, Stack};
 
 const TT_MOVE_SCORE: i32 = 30_000;

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -3,9 +3,9 @@ mod see;
 use arrayvec::ArrayVec;
 
 use crate::chess::movegen::MoveGen;
-use crate::chess::{Color, Move, Position, Role, Square};
-use crate::engine::history::History;
-use crate::engine::search::{MAX_PLY, Search};
+use crate::chess::{Move, Position, Role};
+use crate::engine::history::HistoryTables;
+use crate::engine::search::{MAX_PLY, Search, Stack};
 
 const TT_MOVE_SCORE: i16 = 30_000;
 const GOOD_TACTICAL_SCORE: i16 = 22_000;
@@ -45,6 +45,7 @@ enum MovePickerStage {
 pub enum MovePickerMode {
     Normal,
     Quiescence,
+    QuiescenceCheck,
 }
 
 pub struct MovePicker {
@@ -54,6 +55,7 @@ pub struct MovePicker {
     tt_move: Move,
     killers: [Move; 2],
     margin: i32,
+    ply: usize,
 
     scored_moves: MoveList,
     scored_index: usize,
@@ -63,6 +65,7 @@ pub struct MovePicker {
 impl MovePicker {
     pub fn new(
         pos: &Position,
+        ply: usize,
         mode: MovePickerMode,
         tt_move: Move,
         killers: [Move; 2],
@@ -73,6 +76,7 @@ impl MovePicker {
             move_generator: mg,
             stage: MovePickerStage::TT,
             mode,
+            ply,
             tt_move,
             killers,
             margin,
@@ -90,16 +94,21 @@ impl MovePicker {
 
         let mode = if pos.in_check() {
             // if in check, we need to search all moves
-            MovePickerMode::Normal
+            MovePickerMode::QuiescenceCheck
         } else {
             MovePickerMode::Quiescence
         };
 
-        MovePicker::new(pos, mode, tt_move, [Move::NONE; 2], margin)
+        MovePicker::new(pos, MAX_PLY, mode, tt_move, [Move::NONE; 2], margin)
     }
 
-    pub fn new_ab_search(pos: &Position, tt_move: Move, killers: [Move; 2]) -> MovePicker {
-        MovePicker::new(pos, MovePickerMode::Normal, tt_move, killers, 1)
+    pub fn new_ab_search(
+        pos: &Position,
+        ply: usize,
+        tt_move: Move,
+        killers: [Move; 2],
+    ) -> MovePicker {
+        MovePicker::new(pos, ply, MovePickerMode::Normal, tt_move, killers, 1)
     }
 
     fn mvv_lva(&self, m: Move, position: &Position) -> i16 {
@@ -141,14 +150,7 @@ impl MovePicker {
         self.scored_index = self.scored_moves.len();
     }
 
-    fn score_quiets(
-        &mut self,
-        position: &Position,
-        history: &History,
-        continuation: &[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM],
-        ply: u8,
-        current_move: &[(Move, Option<Role>); MAX_PLY as usize],
-    ) {
+    fn score_quiets(&mut self, history: &HistoryTables, position: &Position, stack: &Stack) {
         for i in self.scored_index..self.scored_moves.len() {
             let m = self.scored_moves[i].m;
             if m == self.killers[0] {
@@ -156,21 +158,7 @@ impl MovePicker {
             } else if m == self.killers[1] {
                 self.scored_moves[i].score = KILLER_2_SCORE as i32;
             } else {
-                let history_bonus = history.score(position.side, m.from(), m.to());
-                let counter_move_bonus = if ply == 0 || ply == MAX_PLY {
-                    0
-                } else {
-                    match current_move[ply as usize - 1] {
-                        (prev_mv, Some(role)) if prev_mv != Move::NULL && prev_mv != Move::NONE => {
-                            let current_role = position.role_at(m.from()).unwrap();
-                            continuation[position.side][role][prev_mv.to()][current_role][m.to()]
-                                as i32
-                        }
-                        _ => 0,
-                    }
-                };
-
-                self.scored_moves[i].score = (history_bonus / 2) + (counter_move_bonus / 2);
+                self.scored_moves[i].score = history.score(position, stack, self.ply, m);
             };
         }
         self.scored_index = self.scored_moves.len();
@@ -205,14 +193,14 @@ impl MovePicker {
         Some(self.scored_moves[self.sorted_index - 1].m)
     }
 
-    pub fn next(&mut self, search: &Search, ply: u8) -> Option<Move> {
+    pub fn next(&mut self, search: &Search) -> Option<Move> {
         match self.stage {
             MovePickerStage::TT => {
                 self.stage = MovePickerStage::ScoreTacticals;
                 if self.tt_move != Move::NONE {
                     return Some(self.tt_move);
                 }
-                self.next(search, ply)
+                self.next(search)
             }
             MovePickerStage::ScoreTacticals => {
                 self.stage = MovePickerStage::Tacticals;
@@ -226,14 +214,14 @@ impl MovePicker {
                 }
 
                 self.score_tacticals(&search.position);
-                self.next(search, ply)
+                self.next(search)
             }
             MovePickerStage::Tacticals => {
                 // Don't need to filter this to enemies, right?
                 match self.select_sorted_min(GOOD_TACTICAL_SCORE as i32) {
                     Some(m) => {
                         if m == self.tt_move {
-                            return self.next(search, ply);
+                            return self.next(search);
                         }
                         Some(m)
                     }
@@ -242,7 +230,7 @@ impl MovePicker {
                             return None;
                         }
                         self.stage = MovePickerStage::ScoreQuiets;
-                        self.next(search, ply)
+                        self.next(search)
                     }
                 }
             }
@@ -254,19 +242,18 @@ impl MovePicker {
                     self.scored_moves.push(MoveWithScore { m, score: 0 });
                 }
 
-                self.score_quiets(
-                    &search.position,
-                    &search.history,
-                    &search.continuation,
-                    ply,
-                    &search.current_move,
-                );
-                self.next(search, ply)
+                if self.mode == MovePickerMode::QuiescenceCheck {
+                    // sortin moves doesn't matter when we're in check in quiescence
+                    return self.next(search);
+                }
+
+                self.score_quiets(&search.history, &search.position, &search.stack);
+                self.next(search)
             }
             MovePickerStage::Quiets => match self.select_sorted() {
                 Some(m) => {
                     if m == self.tt_move {
-                        return self.next(search, ply);
+                        return self.next(search);
                     }
                     Some(m)
                 }

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -4,15 +4,15 @@ use arrayvec::ArrayVec;
 
 use crate::chess::movegen::MoveGen;
 use crate::chess::{Move, Position, Role};
-use crate::engine::history::HistoryTables;
+use crate::engine::history::{HISTORY_MAX, HistoryTables};
 use crate::engine::search::{MAX_PLY, Search, Stack};
 
-const TT_MOVE_SCORE: i16 = 30_000;
-const GOOD_TACTICAL_SCORE: i16 = 22_000;
-const QUEEN_PROMO_BONUS: i16 = 21_002;
-const KILLER_1_SCORE: i16 = 21_001;
-const KILLER_2_SCORE: i16 = 21_000;
-const BAD_TACTICAL_SCORE: i16 = 17_000;
+const TT_MOVE_SCORE: i32 = 30_000;
+const GOOD_TACTICAL_SCORE: i32 = 22_000 + HISTORY_MAX * 2;
+const QUEEN_PROMO_BONUS: i32 = 21_002 + HISTORY_MAX * 2;
+pub const KILLER_1_SCORE: i32 = 21_001 + HISTORY_MAX * 2;
+pub const KILLER_2_SCORE: i32 = 21_000 + HISTORY_MAX * 2;
+const BAD_TACTICAL_SCORE: i32 = 17_000 + HISTORY_MAX * 2;
 
 pub const MAX_MOVES: usize = 256;
 
@@ -53,7 +53,6 @@ pub struct MovePicker {
     stage: MovePickerStage,
     mode: MovePickerMode,
     tt_move: Move,
-    killers: [Move; 2],
     margin: i32,
     ply: usize,
 
@@ -68,7 +67,6 @@ impl MovePicker {
         ply: usize,
         mode: MovePickerMode,
         tt_move: Move,
-        killers: [Move; 2],
         margin: i32,
     ) -> MovePicker {
         let mg = MoveGen::new(pos);
@@ -78,7 +76,6 @@ impl MovePicker {
             mode,
             ply,
             tt_move,
-            killers,
             margin,
             scored_moves: ArrayVec::new(),
             scored_index: 0,
@@ -99,16 +96,11 @@ impl MovePicker {
             MovePickerMode::Quiescence
         };
 
-        MovePicker::new(pos, MAX_PLY, mode, tt_move, [Move::NONE; 2], margin)
+        MovePicker::new(pos, MAX_PLY, mode, tt_move, margin)
     }
 
-    pub fn new_ab_search(
-        pos: &Position,
-        ply: usize,
-        tt_move: Move,
-        killers: [Move; 2],
-    ) -> MovePicker {
-        MovePicker::new(pos, ply, MovePickerMode::Normal, tt_move, killers, 1)
+    pub fn new_ab_search(pos: &Position, ply: usize, tt_move: Move) -> MovePicker {
+        MovePicker::new(pos, ply, MovePickerMode::Normal, tt_move, 1)
     }
 
     fn mvv_lva(&self, m: Move, position: &Position) -> i16 {
@@ -153,13 +145,7 @@ impl MovePicker {
     fn score_quiets(&mut self, history: &HistoryTables, position: &Position, stack: &Stack) {
         for i in self.scored_index..self.scored_moves.len() {
             let m = self.scored_moves[i].m;
-            if m == self.killers[0] {
-                self.scored_moves[i].score = KILLER_1_SCORE as i32;
-            } else if m == self.killers[1] {
-                self.scored_moves[i].score = KILLER_2_SCORE as i32;
-            } else {
-                self.scored_moves[i].score = history.score(position, stack, self.ply, m);
-            };
+            self.scored_moves[i].score = history.score(position, stack, self.ply, m);
         }
         self.scored_index = self.scored_moves.len();
     }

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -16,7 +16,7 @@ const BAD_TACTICAL_SCORE: i32 = 17_000 + HISTORY_MAX * 2;
 
 pub const MAX_MOVES: usize = 256;
 
-const MVV_LVA: [[i16; 6]; 6] = [
+const MVV_LVA: [[i32; 6]; 6] = [
     [15, 25, 35, 45, 55, 0], // attacker pawn, victim P, N, B, R, Q,  K
     [14, 24, 34, 44, 54, 0], // attacker knight, victim P, N, B, R, Q,  K
     [13, 23, 33, 43, 53, 0], // attacker bishop, victim P, N, B, R, Q,  K
@@ -103,7 +103,7 @@ impl MovePicker {
         MovePicker::new(pos, ply, MovePickerMode::Normal, tt_move, 1)
     }
 
-    fn mvv_lva(&self, m: Move, position: &Position) -> i16 {
+    fn mvv_lva(&self, m: Move, position: &Position) -> i32 {
         let attacker = position.role_at(m.from());
         let victim = m.captured_role(position);
 
@@ -118,24 +118,22 @@ impl MovePicker {
         for i in 0..self.scored_moves.len() {
             self.scored_moves[i].score = {
                 if self.scored_moves[i].m == self.tt_move {
-                    TT_MOVE_SCORE as i32
+                    TT_MOVE_SCORE
                 } else if self.scored_moves[i].m.is_promotion() {
                     match self.scored_moves[i].m.promotion() {
                         Some(Role::Queen) => {
                             if see::see(position, self.scored_moves[i].m, self.margin) {
-                                QUEEN_PROMO_BONUS as i32 + GOOD_TACTICAL_SCORE as i32
+                                QUEEN_PROMO_BONUS + GOOD_TACTICAL_SCORE
                             } else {
-                                QUEEN_PROMO_BONUS as i32 + BAD_TACTICAL_SCORE as i32
+                                QUEEN_PROMO_BONUS + BAD_TACTICAL_SCORE
                             }
                         }
-                        _ => BAD_TACTICAL_SCORE as i32,
+                        _ => BAD_TACTICAL_SCORE,
                     }
                 } else if see::see(position, self.scored_moves[i].m, self.margin) {
-                    self.mvv_lva(self.scored_moves[i].m, position) as i32
-                        + GOOD_TACTICAL_SCORE as i32
+                    self.mvv_lva(self.scored_moves[i].m, position) + GOOD_TACTICAL_SCORE
                 } else {
-                    self.mvv_lva(self.scored_moves[i].m, position) as i32
-                        + BAD_TACTICAL_SCORE as i32
+                    self.mvv_lva(self.scored_moves[i].m, position) + BAD_TACTICAL_SCORE
                 }
             }
         }
@@ -204,7 +202,7 @@ impl MovePicker {
             }
             MovePickerStage::Tacticals => {
                 // Don't need to filter this to enemies, right?
-                match self.select_sorted_min(GOOD_TACTICAL_SCORE as i32) {
+                match self.select_sorted_min(GOOD_TACTICAL_SCORE) {
                     Some(m) => {
                         if m == self.tt_move {
                             return self.next(search);

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -3,16 +3,16 @@ use std::time::Instant;
 
 use arrayvec::ArrayVec;
 
-use crate::chess::{Accumulator, Color, GameResult, Move, Position, Role, Square};
+use crate::chess::{Accumulator, GameResult, Move, Position, Role, Square};
 use crate::engine::eval::{self, nnue};
-use crate::engine::history::History;
+use crate::engine::history::HistoryTables;
 use crate::engine::limits::Limits;
 use crate::engine::movepicker::{MAX_MOVES, MovePicker};
 use crate::engine::time_management::SearchCop;
 use crate::engine::tt::{Entry, EntryType, Table};
 
 const MAX_DEPTH: u8 = 64;
-pub const MAX_PLY: u8 = 128;
+pub const MAX_PLY: usize = 128;
 
 static mut REDUCTIONS: [[u8; MAX_MOVES]; MAX_DEPTH as usize] = [[0; MAX_MOVES]; MAX_DEPTH as usize];
 
@@ -38,8 +38,8 @@ pub struct SearchResult {
 pub struct Stats {
     pub nodes: u64,
     pub effort: [[u64; Square::NUM]; Square::NUM],
-    pub pv: [[Move; MAX_PLY as usize]; MAX_PLY as usize],
-    pub pv_length: [u8; MAX_PLY as usize],
+    pub pv: [[Move; MAX_PLY]; MAX_PLY],
+    pub pv_length: [u8; MAX_PLY],
     pub start_time: Instant,
 }
 
@@ -48,8 +48,8 @@ impl Default for Stats {
         Self {
             nodes: 0,
             effort: [[0; Square::NUM]; Square::NUM],
-            pv: [[Move::NONE; MAX_PLY as usize]; MAX_PLY as usize],
-            pv_length: [0; MAX_PLY as usize],
+            pv: [[Move::NONE; MAX_PLY]; MAX_PLY],
+            pv_length: [0; MAX_PLY],
             start_time: Instant::now(),
         }
     }
@@ -59,8 +59,8 @@ impl Stats {
     fn reset(&mut self) {
         self.nodes = 0;
         self.effort = [[0; Square::NUM]; Square::NUM];
-        self.pv = [[Move::NONE; MAX_PLY as usize]; MAX_PLY as usize];
-        self.pv_length = [0; MAX_PLY as usize];
+        self.pv = [[Move::NONE; MAX_PLY]; MAX_PLY];
+        self.pv_length = [0; MAX_PLY];
         self.start_time = Instant::now();
     }
 
@@ -105,18 +105,35 @@ impl Stats {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct Frame {
+    pub mv: Move,
+    pub moved: Option<Role>,
+    pub eval: i16,
+}
+
+pub type Stack = [Frame; MAX_PLY];
+
+impl Default for Frame {
+    fn default() -> Self {
+        Self {
+            mv: Move::NONE,
+            moved: None,
+            eval: eval::NO_VALUE,
+        }
+    }
+}
+
 pub struct Search<'a> {
     pub stats: Stats,
 
     pub position: Position,
     accum: eval::nnue::NNUEAccumulator<'a, { eval::nnue::NNUE_HIDDEN_SIZE }>,
 
-    pub current_move: [(Move, Option<Role>); MAX_PLY as usize],
-    pub history: History,
-    pub continuation:
-        Box<[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM]>,
-    killers: [[Move; 2]; MAX_PLY as usize],
-    eval: [i16; MAX_PLY as usize],
+    pub stack: Stack,
+    pub history: HistoryTables,
+
+    killers: [[Move; 2]; MAX_PLY],
     tt: &'a Table,
 
     tm: SearchCop,
@@ -142,13 +159,9 @@ impl<'a> Search<'a> {
         accum.reset(&position);
         Search {
             accum,
-            current_move: [(Move::NONE, None); MAX_PLY as usize],
-            history: History::default(),
-            continuation: Box::new(
-                [[[[[0; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM],
-            ),
-            killers: [[Move::NONE; 2]; MAX_PLY as usize],
-            eval: [eval::NO_VALUE; MAX_PLY as usize],
+            history: HistoryTables::default(),
+            killers: [[Move::NONE; 2]; MAX_PLY],
+            stack: [Frame::default(); MAX_PLY],
             tm: SearchCop::new(limits, side),
             position,
             silent,
@@ -246,7 +259,7 @@ impl<'a> Search<'a> {
         mut depth: i32,
         mut alpha: i16,
         beta: i16,
-        ply: u8,
+        ply: usize,
         is_pv: bool,
         is_root: bool,
     ) -> i16 {
@@ -257,7 +270,7 @@ impl<'a> Search<'a> {
             return eval::score_nnue(&self.position, &self.accum);
         }
 
-        self.stats.pv_length[ply as usize] = ply;
+        self.stats.pv_length[ply] = ply as u8;
 
         if depth <= 0 {
             return self.quiescence_search(alpha, beta, is_pv);
@@ -337,14 +350,14 @@ impl<'a> Search<'a> {
             ));
         }
 
-        self.eval[ply as usize] = static_eval;
+        self.stack[ply].eval = static_eval;
 
         let improving = if self.position.in_check() {
             false
-        } else if ply > 1 && self.eval[ply as usize - 2] != eval::NO_VALUE {
-            self.eval[ply as usize] > self.eval[ply as usize - 2]
-        } else if ply > 3 && self.eval[ply as usize - 4] != eval::NO_VALUE {
-            self.eval[ply as usize] > self.eval[ply as usize - 4]
+        } else if ply > 1 && self.stack[ply - 2].eval != eval::NO_VALUE {
+            self.stack[ply].eval > self.stack[ply - 2].eval
+        } else if ply > 3 && self.stack[ply - 4].eval != eval::NO_VALUE {
+            self.stack[ply].eval > self.stack[ply - 4].eval
         } else {
             false
         };
@@ -374,18 +387,21 @@ impl<'a> Search<'a> {
             && self.position.non_pawn_material(self.position.side)
             && !self.position.in_check()
             && static_eval >= beta
-            && (ply < 1 || self.current_move[(ply - 1) as usize].0 != Move::NULL)
+            && (ply < 1 || self.stack[ply - 1].mv != Move::NULL)
         {
             self.position.make_null_move_with(&mut self.accum);
-            let prev_move = self.current_move[ply as usize];
+            let prev_move = self.stack[ply].mv;
+            let prev_moved = self.stack[ply].moved;
 
-            self.current_move[ply as usize] = (Move::NULL, None);
+            self.stack[ply].mv = Move::NULL;
+            self.stack[ply].moved = None;
 
             let reduced_depth = depth - (3 + (depth / 5));
             let null_score = -self.search(reduced_depth, -beta, -beta + 1, ply + 1, false, false);
 
             self.position.unmake_null_move_with(&mut self.accum);
-            self.current_move[ply as usize] = prev_move;
+            self.stack[ply].mv = prev_move;
+            self.stack[ply].moved = prev_moved;
 
             if null_score >= beta {
                 if null_score >= (eval::MATE_IN_PLY) {
@@ -402,8 +418,8 @@ impl<'a> Search<'a> {
         let mut quiets: ArrayVec<Move, 64> = ArrayVec::new();
 
         let mut move_picker =
-            MovePicker::new_ab_search(&self.position, tt_move, self.killers[ply as usize]);
-        while let Some(mv) = move_picker.next(self, ply) {
+            MovePicker::new_ab_search(&self.position, ply, tt_move, self.killers[ply]);
+        while let Some(mv) = move_picker.next(self) {
             move_count += 1;
             let capture = mv.is_capture(&self.position);
 
@@ -413,8 +429,8 @@ impl<'a> Search<'a> {
                 && !self.position.in_check()
                 && depth <= 3
                 && move_count > (3 + depth * depth) as u8
-                && mv != self.killers[ply as usize][0]
-                && mv != self.killers[ply as usize][1]
+                && mv != self.killers[ply][0]
+                && mv != self.killers[ply][1]
             {
                 continue;
             }
@@ -443,7 +459,8 @@ impl<'a> Search<'a> {
                 new_depth += 1;
             }
 
-            self.current_move[ply as usize] = (mv, self.position.role_at(mv.from()));
+            self.stack[ply].mv = mv;
+            self.stack[ply].moved = self.position.role_at(mv.from());
             self.position.make_move_with(mv, &mut self.accum);
 
             let mut score = -eval::INFINITY;
@@ -479,7 +496,8 @@ impl<'a> Search<'a> {
             }
 
             self.position.unmake_move_with(mv, &mut self.accum);
-            self.current_move[ply as usize] = (Move::NONE, None);
+            self.stack[ply].mv = Move::NONE;
+            self.stack[ply].moved = None;
 
             // store effort at root
             if is_root {
@@ -490,36 +508,30 @@ impl<'a> Search<'a> {
                 best = score;
                 best_move = mv;
 
-                self.stats.pv[ply as usize][ply as usize] = mv;
-                for j in (ply + 1)..self.stats.pv_length[ply as usize + 1] {
-                    self.stats.pv[ply as usize][j as usize] =
-                        self.stats.pv[ply as usize + 1][j as usize];
+                self.stats.pv[ply][ply] = mv;
+                for j in (ply + 1)..self.stats.pv_length[ply + 1] as usize {
+                    self.stats.pv[ply][j] = self.stats.pv[ply + 1][j];
                 }
 
-                self.stats.pv_length[ply as usize] = self.stats.pv_length[ply as usize + 1];
+                self.stats.pv_length[ply] = self.stats.pv_length[ply + 1];
 
                 if score > alpha {
                     alpha = score;
                     if score >= beta {
                         if !capture {
                             self.update_killers(mv, ply);
-                            let bonus = 2000.min(350 * depth as i16 - 350);
-                            self.history.update(
-                                self.position.side,
-                                mv.from(),
-                                mv.to(),
-                                bonus as i32,
-                            );
-                            self.update_continuation(mv, bonus, ply);
+                            let bonus = 2000.min(350 * depth - 350);
+                            self.history
+                                .update(&self.position, &self.stack, ply, mv, bonus);
 
                             for quiet in quiets.iter() {
                                 self.history.update(
-                                    self.position.side,
-                                    quiet.from(),
-                                    quiet.to(),
-                                    bonus as i32,
+                                    &self.position,
+                                    &self.stack,
+                                    ply,
+                                    *quiet,
+                                    -bonus / 2,
                                 );
-                                self.update_continuation(*quiet, -bonus / 2, ply);
                             }
                         }
 
@@ -650,7 +662,7 @@ impl<'a> Search<'a> {
 
         let see_margin = alpha.saturating_sub(stand_pat).saturating_sub(500).max(1) as i32;
         let mut move_picker = MovePicker::new_quiescence(&self.position, tt_move, see_margin);
-        while let Some(mv) = move_picker.next(self, MAX_PLY) {
+        while let Some(mv) = move_picker.next(self) {
             self.position.make_move_with(mv, &mut self.accum);
             let score = -self.quiescence_search(-beta, -alpha, is_pv);
             self.position.unmake_move_with(mv, &mut self.accum);
@@ -693,27 +705,9 @@ impl<'a> Search<'a> {
         best
     }
 
-    pub fn update_killers(&mut self, mv: Move, ply: u8) {
-        self.killers[ply as usize][1] = self.killers[ply as usize][0];
-        self.killers[ply as usize][0] = mv;
-    }
-
-    fn update_continuation(&mut self, mv: Move, bonus: i16, ply: u8) {
-        if ply < 1 {
-            return;
-        }
-        match self.current_move[ply as usize - 1] {
-            (prev_mv, Some(role)) if prev_mv != Move::NULL && prev_mv != Move::NONE => {
-                let current_role = self.position.role_at(mv.from()).unwrap();
-                self.continuation[self.position.side][role][prev_mv.to()][current_role][mv.to()] +=
-                    bonus
-                        - ((self.continuation[self.position.side][role][prev_mv.to()][current_role]
-                            [mv.to()] as i32
-                            * bonus.abs() as i32)
-                            / 16384) as i16;
-            }
-            _ => {}
-        }
+    pub fn update_killers(&mut self, mv: Move, ply: usize) {
+        self.killers[ply][1] = self.killers[ply][0];
+        self.killers[ply][0] = mv;
     }
 
     fn reduction(&self, depth: i32, move_count: u8) -> i32 {
@@ -740,7 +734,7 @@ impl<'a> Search<'a> {
     }
 }
 
-fn normalize_score(score: i16, ply: u8) -> i16 {
+fn normalize_score(score: i16, ply: usize) -> i16 {
     if (eval::MATE_IN_PLY..=eval::MATE).contains(&score) {
         score + ply as i16
     } else if (-eval::MATE..=-eval::MATE_IN_PLY).contains(&score) {
@@ -750,7 +744,7 @@ fn normalize_score(score: i16, ply: u8) -> i16 {
     }
 }
 
-fn denormalize_score(score: i16, ply: u8) -> i16 {
+fn denormalize_score(score: i16, ply: usize) -> i16 {
     if (eval::MATE_IN_PLY..=eval::MATE).contains(&score) {
         score - ply as i16
     } else if (-eval::MATE..=-eval::MATE_IN_PLY).contains(&score) {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -5,6 +5,7 @@ use arrayvec::ArrayVec;
 
 use crate::chess::{Accumulator, Color, GameResult, Move, Position, Role, Square};
 use crate::engine::eval::{self, nnue};
+use crate::engine::history::History;
 use crate::engine::limits::Limits;
 use crate::engine::movepicker::{MAX_MOVES, MovePicker};
 use crate::engine::time_management::SearchCop;
@@ -111,7 +112,7 @@ pub struct Search<'a> {
     accum: eval::nnue::NNUEAccumulator<'a, { eval::nnue::NNUE_HIDDEN_SIZE }>,
 
     pub current_move: [(Move, Option<Role>); MAX_PLY as usize],
-    pub history: [[[i16; Square::NUM]; Square::NUM]; Color::NUM],
+    pub history: History,
     pub continuation:
         Box<[[[[[i16; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM]>,
     killers: [[Move; 2]; MAX_PLY as usize],
@@ -142,7 +143,7 @@ impl<'a> Search<'a> {
         Search {
             accum,
             current_move: [(Move::NONE, None); MAX_PLY as usize],
-            history: [[[0; Square::NUM]; Square::NUM]; Color::NUM],
+            history: History::default(),
             continuation: Box::new(
                 [[[[[0; Square::NUM]; Role::NUM]; Square::NUM]; Role::NUM]; Color::NUM],
             ),
@@ -503,11 +504,21 @@ impl<'a> Search<'a> {
                         if !capture {
                             self.update_killers(mv, ply);
                             let bonus = 2000.min(350 * depth as i16 - 350);
-                            self.update_history(mv, bonus);
+                            self.history.update(
+                                self.position.side,
+                                mv.from(),
+                                mv.to(),
+                                bonus as i32,
+                            );
                             self.update_continuation(mv, bonus, ply);
 
                             for quiet in quiets.iter() {
-                                self.update_history(*quiet, -bonus / 2);
+                                self.history.update(
+                                    self.position.side,
+                                    quiet.from(),
+                                    quiet.to(),
+                                    bonus as i32,
+                                );
                                 self.update_continuation(*quiet, -bonus / 2, ply);
                             }
                         }
@@ -685,12 +696,6 @@ impl<'a> Search<'a> {
     pub fn update_killers(&mut self, mv: Move, ply: u8) {
         self.killers[ply as usize][1] = self.killers[ply as usize][0];
         self.killers[ply as usize][0] = mv;
-    }
-
-    fn update_history(&mut self, mv: Move, bonus: i16) {
-        self.history[self.position.side][mv.from()][mv.to()] += bonus
-            - ((self.history[self.position.side][mv.from()][mv.to()] as i32 * bonus.abs() as i32)
-                / 16384) as i16;
     }
 
     fn update_continuation(&mut self, mv: Move, bonus: i16, ply: u8) {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -426,6 +426,7 @@ impl<'a> Search<'a> {
                 && !self.position.in_check()
                 && depth <= 3
                 && move_count > (3 + depth * depth) as u8
+                && self.history.is_killer(ply, mv)
             {
                 continue;
             }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -712,7 +712,7 @@ impl<'a> Search<'a> {
             return true;
         }
 
-        if self.stats.nodes % 2048 == 0 && self.tm.time_up(&self.stats) {
+        if self.stats.nodes.is_multiple_of(2048) && self.tm.time_up(&self.stats) {
             self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
             return true;
         }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -426,7 +426,7 @@ impl<'a> Search<'a> {
                 && !self.position.in_check()
                 && depth <= 3
                 && move_count > (3 + depth * depth) as u8
-                && self.history.is_killer(ply, mv)
+                && !self.history.is_killer(ply, mv)
             {
                 continue;
             }

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -133,7 +133,6 @@ pub struct Search<'a> {
     pub stack: Stack,
     pub history: HistoryTables,
 
-    killers: [[Move; 2]; MAX_PLY],
     tt: &'a Table,
 
     tm: SearchCop,
@@ -160,7 +159,6 @@ impl<'a> Search<'a> {
         Search {
             accum,
             history: HistoryTables::default(),
-            killers: [[Move::NONE; 2]; MAX_PLY],
             stack: [Frame::default(); MAX_PLY],
             tm: SearchCop::new(limits, side),
             position,
@@ -417,8 +415,7 @@ impl<'a> Search<'a> {
         let mut move_count = 0;
         let mut quiets: ArrayVec<Move, 64> = ArrayVec::new();
 
-        let mut move_picker =
-            MovePicker::new_ab_search(&self.position, ply, tt_move, self.killers[ply]);
+        let mut move_picker = MovePicker::new_ab_search(&self.position, ply, tt_move);
         while let Some(mv) = move_picker.next(self) {
             move_count += 1;
             let capture = mv.is_capture(&self.position);
@@ -429,8 +426,6 @@ impl<'a> Search<'a> {
                 && !self.position.in_check()
                 && depth <= 3
                 && move_count > (3 + depth * depth) as u8
-                && mv != self.killers[ply][0]
-                && mv != self.killers[ply][1]
             {
                 continue;
             }
@@ -519,7 +514,7 @@ impl<'a> Search<'a> {
                     alpha = score;
                     if score >= beta {
                         if !capture {
-                            self.update_killers(mv, ply);
+                            self.history.update_killers(mv, ply);
                             let bonus = 2000.min(350 * depth - 350);
                             self.history
                                 .update(&self.position, &self.stack, ply, mv, bonus);
@@ -703,11 +698,6 @@ impl<'a> Search<'a> {
         }
 
         best
-    }
-
-    pub fn update_killers(&mut self, mv: Move, ply: usize) {
-        self.killers[ply][1] = self.killers[ply][0];
-        self.killers[ply][0] = mv;
     }
 
     fn reduction(&self, depth: i32, move_count: u8) -> i32 {


### PR DESCRIPTION
```
ref [completed]
refactor (h@16mb th@1) vs main (h@16mb th@1)

elo = -2.90 [-7.24, 1.07] (95%)
llr = 2.94 (accepted) | sprt = (-10.00, 0.00) [-2.94, 2.94]
wdl = 4369/10984/4485 (22.0%/55.4%/22.6%) | penta = 449/2411/4302/2321/436
games = 19838
```
