### PR TITLE
nit: correct improving condition

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -357,7 +357,7 @@ impl<'a> Search<'a> {
         } else if ply > 3 && self.stack[ply - 4].eval != eval::NO_VALUE {
             self.stack[ply].eval > self.stack[ply - 4].eval
         } else {
-            false
+            true
         };
 
         let tt_move = tt_hit.map_or(Move::NONE, |tt| tt.best_move);


### PR DESCRIPTION
```
imp2 [completed]
imp-2 (h@16mb th@1) vs main (h@16mb th@1)

elo = 2.54 [-2.16, 7.18] (95%)
llr = 2.94 (accepted) | sprt = (-5.00, 0.00) [-2.94, 2.94]
wdl = 2248/5579/2159 (22.5%/55.9%/21.6%) | penta = 226/1223/2027/1270/247
games = 9986
```