### PR TITLE
refactor: remove atomic tt code

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -298,10 +298,10 @@ impl<'a> Search<'a> {
             if !is_pv
                 && self.position.halfmove_clock < 80
                 && hit.depth as i32 >= depth
-                && (hit.score_type == EntryType::Exact
-                    || (hit.score_type == EntryType::LowerBound
+                && (hit.score_type() == EntryType::Exact
+                    || (hit.score_type() == EntryType::LowerBound
                         && denormalize_score(hit.score, ply) >= beta)
-                    || (hit.score_type == EntryType::UpperBound
+                    || (hit.score_type() == EntryType::UpperBound
                         && denormalize_score(hit.score, ply) <= alpha))
             {
                 return denormalize_score(hit.score, ply);
@@ -314,22 +314,16 @@ impl<'a> Search<'a> {
         let static_eval;
         if self.position.in_check() {
             static_eval = eval::NO_VALUE;
-        } else if let Some(Entry {
-            score: tt_score,
-            static_eval: tt_static_eval,
-            score_type,
-            ..
-        }) = tt_hit
-        {
-            let eval = if tt_static_eval != eval::NO_VALUE {
-                denormalize_score(tt_score, ply)
+        } else if let Some(entry) = tt_hit {
+            let eval = if entry.static_eval != eval::NO_VALUE {
+                denormalize_score(entry.score, ply)
             } else {
                 eval::score_nnue(&self.position, &self.accum)
             };
 
-            let denormalized_score = denormalize_score(tt_score, ply);
+            let denormalized_score = denormalize_score(entry.score, ply);
 
-            static_eval = match score_type {
+            static_eval = match entry.score_type() {
                 EntryType::Exact => denormalized_score,
                 EntryType::LowerBound if denormalized_score > eval => denormalized_score,
                 EntryType::UpperBound if denormalized_score < eval => denormalized_score,
@@ -592,10 +586,10 @@ impl<'a> Search<'a> {
         let tt_hit = if let Some(hit) = self.tt.probe(self.position.key) {
             if !is_pv
                 && self.position.halfmove_clock < 80
-                && (hit.score_type == EntryType::Exact
-                    || (hit.score_type == EntryType::LowerBound
+                && (hit.score_type() == EntryType::Exact
+                    || (hit.score_type() == EntryType::LowerBound
                         && denormalize_score(hit.score, MAX_PLY) >= beta)
-                    || (hit.score_type == EntryType::UpperBound
+                    || (hit.score_type() == EntryType::UpperBound
                         && denormalize_score(hit.score, MAX_PLY) <= alpha))
             {
                 return denormalize_score(hit.score, MAX_PLY);
@@ -610,22 +604,16 @@ impl<'a> Search<'a> {
 
         if self.position.in_check() {
             stand_pat = -eval::INFINITY;
-        } else if let Some(Entry {
-            score: tt_score,
-            static_eval: tt_static_eval,
-            score_type,
-            ..
-        }) = tt_hit
-        {
-            let eval = if tt_static_eval != eval::NO_VALUE {
-                denormalize_score(tt_static_eval, MAX_PLY)
+        } else if let Some(entry) = tt_hit {
+            let eval = if entry.static_eval != eval::NO_VALUE {
+                denormalize_score(entry.static_eval, MAX_PLY)
             } else {
                 eval::score_nnue(&self.position, &self.accum)
             };
 
-            let denormalized_score = denormalize_score(tt_score, MAX_PLY);
+            let denormalized_score = denormalize_score(entry.score, MAX_PLY);
 
-            stand_pat = match score_type {
+            stand_pat = match entry.score_type() {
                 EntryType::Exact => denormalized_score,
                 EntryType::LowerBound if denormalized_score > eval => denormalized_score,
                 EntryType::UpperBound if denormalized_score < eval => denormalized_score,

--- a/src/engine/search_manager.rs
+++ b/src/engine/search_manager.rs
@@ -50,21 +50,30 @@ impl SearchManager {
         self.tt.clear();
     }
 
-    pub fn think_with_stop(&self, limits: Limits, stop: Arc<AtomicBool>) -> (SearchResult, u64) {
+    pub fn think_with_stop(
+        &mut self,
+        limits: Limits,
+        stop: Arc<AtomicBool>,
+    ) -> (SearchResult, u64) {
         stop.store(false, std::sync::atomic::Ordering::Relaxed);
-        self.tt.increment_age();
-        thread::scope(|s| {
-            let mut handles = Vec::with_capacity(self.num_threads);
+        self.tt.age += 1;
 
-            for thread_idx in 0..self.num_threads {
-                let position = self.position.clone();
-                let tt = &self.tt;
-                let silent = self.silent;
+        let tt = &self.tt;
+        let net = &self.net;
+        let position = &self.position;
+        let num_threads = self.num_threads;
+        let silent = self.silent;
+
+        thread::scope(|s| {
+            let mut handles = Vec::with_capacity(num_threads);
+
+            for thread_idx in 0..num_threads {
+                let position = position.clone();
                 let stop = &stop;
 
                 let handle = s.spawn(move || {
                     let mut search =
-                        Search::new(position, limits, tt, stop, thread_idx, silent, &self.net);
+                        Search::new(position, limits, tt, stop, thread_idx, silent, net);
                     let result = search.think();
                     (result, search.stats)
                 });
@@ -99,7 +108,7 @@ impl SearchManager {
         })
     }
 
-    pub fn think(&self, limits: Limits) -> (SearchResult, u64) {
+    pub fn think(&mut self, limits: Limits) -> (SearchResult, u64) {
         self.think_with_stop(limits, Arc::new(AtomicBool::new(false)))
     }
 }

--- a/src/engine/tt.rs
+++ b/src/engine/tt.rs
@@ -1,42 +1,27 @@
-use std::sync::atomic::{AtomicU8, AtomicU64};
+use std::cell::UnsafeCell;
 
 use crate::chess::Move;
 use crate::zobrist::ZobristHash;
-
-#[derive(Debug)]
-#[repr(C)]
-struct TTMemory {
-    key: AtomicU64,
-    data: AtomicU64,
-}
-
-impl Default for TTMemory {
-    fn default() -> Self {
-        Self {
-            key: AtomicU64::new(0),
-            data: AtomicU64::new(0),
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[repr(u8)]
 pub enum EntryType {
     #[default]
-    None,
-    UpperBound,
-    LowerBound,
-    Exact,
+    None = 0,
+    UpperBound = 1,
+    LowerBound = 2,
+    Exact = 3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
+#[repr(C)]
 pub struct Entry {
     pub key: ZobristHash,
-    pub depth: u8,
     pub static_eval: i16,
     pub score: i16,
-    pub score_type: EntryType,
     pub best_move: Move,
+    pub depth: u8,
+    age_and_type: u8, // Top 2 bits: EntryType, Bottom 6 bits: age
 }
 
 impl Entry {
@@ -53,135 +38,68 @@ impl Entry {
             depth,
             static_eval,
             score,
-            score_type,
             best_move,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Default)]
-struct TTData {
-    key: ZobristHash,
-    depth: u8,
-    static_eval: i16,
-    score: i16,
-    score_type: EntryType,
-    best_move: Move,
-    age: u8,
-}
-
-impl TTData {
-    const MOVE_BITS: u32 = 16;
-    const MOVE_MASK: u64 = (1 << Self::MOVE_BITS) - 1;
-
-    const SCORE_SHIFT: u32 = 16;
-    const SCORE_BITS: u32 = 16;
-    const SCORE_MASK: u64 = (1 << Self::SCORE_BITS) - 1;
-
-    const STATIC_EVAL_SHIFT: u32 = 32;
-    const STATIC_EVAL_BITS: u32 = 16;
-    const STATIC_EVAL_MASK: u64 = (1 << Self::STATIC_EVAL_BITS) - 1;
-
-    const DEPTH_SHIFT: u32 = 48;
-    const DEPTH_BITS: u32 = 8;
-    const DEPTH_MASK: u64 = (1 << Self::DEPTH_BITS) - 1;
-
-    const TYPE_SHIFT: u32 = 56;
-    const TYPE_BITS: u32 = 2;
-    const TYPE_MASK: u64 = (1 << Self::TYPE_BITS) - 1;
-
-    const AGE_SHIFT: u32 = 58;
-    const AGE_BITS: u32 = 6;
-    const AGE_MASK: u64 = (1 << Self::AGE_BITS) - 1;
-
-    fn pack(&self) -> u64 {
-        unsafe {
-            ((std::mem::transmute::<Move, u16>(self.best_move) as u64) & Self::MOVE_MASK)
-                | (((self.score as u64) & Self::SCORE_MASK) << Self::SCORE_SHIFT)
-                | (((self.static_eval as u64) & Self::STATIC_EVAL_MASK) << Self::STATIC_EVAL_SHIFT)
-                | (((self.depth as u64) & Self::DEPTH_MASK) << Self::DEPTH_SHIFT)
-                | ((self.score_type as u8 as u64 & Self::TYPE_MASK) << Self::TYPE_SHIFT)
-                | ((self.age as u64 & Self::AGE_MASK) << Self::AGE_SHIFT)
+            age_and_type: (score_type as u8) << 6, // Type in top 2 bits, age=0
         }
     }
 
-    fn unpack(mem_key: u64, data: u64) -> Self {
-        unsafe {
-            let key = std::mem::transmute::<u64, ZobristHash>(mem_key ^ data);
-            let depth = ((data >> Self::DEPTH_SHIFT) & Self::DEPTH_MASK) as u8;
-            let static_eval = ((data >> Self::STATIC_EVAL_SHIFT) & Self::STATIC_EVAL_MASK) as i16;
-            let score = ((data >> Self::SCORE_SHIFT) & Self::SCORE_MASK) as i16;
-            let score_type = std::mem::transmute::<u8, EntryType>(
-                ((data >> Self::TYPE_SHIFT) & Self::TYPE_MASK) as u8,
-            );
-            let best_move = std::mem::transmute::<u16, Move>((data & Self::MOVE_MASK) as u16);
-            let age = ((data >> Self::AGE_SHIFT) & Self::AGE_MASK) as u8;
-
-            Self {
-                key,
-                depth,
-                static_eval,
-                score,
-                score_type,
-                best_move,
-                age,
-            }
+    #[inline]
+    pub fn score_type(&self) -> EntryType {
+        // Extract top 2 bits
+        match self.age_and_type >> 6 {
+            0 => EntryType::None,
+            1 => EntryType::UpperBound,
+            2 => EntryType::LowerBound,
+            3 => EntryType::Exact,
+            _ => unreachable!(),
         }
     }
 
-    fn write(&self, mem: &TTMemory) {
-        let data = self.pack();
-        let key = u64::from(self.key) ^ data;
-        mem.key.store(key, std::sync::atomic::Ordering::Relaxed);
-        mem.data.store(data, std::sync::atomic::Ordering::Relaxed);
+    #[inline]
+    pub fn age(&self) -> u8 {
+        // Extract bottom 6 bits
+        self.age_and_type & 0x3F
     }
-}
 
-impl From<&TTData> for TTMemory {
-    fn from(tt_data: &TTData) -> Self {
-        let data = tt_data.pack();
-        let key = u64::from(tt_data.key) ^ data;
-        TTMemory {
-            key: AtomicU64::new(key),
-            data: AtomicU64::new(data),
-        }
-    }
-}
-
-impl From<&TTMemory> for TTData {
-    fn from(mem: &TTMemory) -> Self {
-        let key = mem.key.load(std::sync::atomic::Ordering::Relaxed);
-        let data = mem.data.load(std::sync::atomic::Ordering::Relaxed);
-        Self::unpack(key, data)
+    #[inline]
+    fn set_age_and_type(&mut self, age: u8, score_type: EntryType) {
+        // Combine type (top 2 bits) and age (bottom 6 bits)
+        self.age_and_type = ((score_type as u8) << 6) | (age & 0x3F);
     }
 }
 
 pub struct Table {
-    entries: Vec<TTMemory>,
-    age: AtomicU8,
+    entries: Vec<UnsafeCell<Entry>>,
+    pub age: u8, // Only uses bottom 6 bits
 }
+
+// We're naughty
+unsafe impl Sync for Table {}
+unsafe impl Send for Table {}
 
 impl Table {
     pub fn new(size: usize) -> Self {
         Self {
-            entries: (0..size).map(|_| TTMemory::default()).collect(),
-            age: AtomicU8::new(0),
+            entries: (0..size)
+                .map(|_| UnsafeCell::new(Entry::default()))
+                .collect(),
+            age: 0,
         }
     }
 
     pub fn new_mb(size_mb: usize) -> Self {
-        Self::new(size_mb * 1024 * 1024 / std::mem::size_of::<TTMemory>())
+        Self::new(size_mb * 1024 * 1024 / std::mem::size_of::<Entry>())
     }
 
-    pub fn clear(&self) {
-        self.entries.iter().for_each(|mem| {
-            mem.key.store(0, std::sync::atomic::Ordering::Relaxed);
-            mem.data.store(0, std::sync::atomic::Ordering::Relaxed);
+    pub fn clear(&mut self) {
+        self.entries.iter_mut().for_each(|cell| {
+            *cell.get_mut() = Entry::default();
         });
     }
 
-    pub fn increment_age(&self) {
-        self.age.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    pub fn increment_age(&mut self) {
+        // Wrap at 6 bits (0-63)
+        self.age = (self.age + 1) & 0x3F;
     }
 
     fn index(&self, key: ZobristHash) -> usize {
@@ -192,59 +110,50 @@ impl Table {
 
     pub fn probe(&self, key: ZobristHash) -> Option<Entry> {
         let idx = self.index(key);
-        let data = TTData::from(&self.entries[idx]);
-        match data.key == key {
-            true => Some(Entry {
-                key: data.key,
-                depth: data.depth,
-                static_eval: data.static_eval,
-                score: data.score,
-                score_type: data.score_type,
-                best_move: data.best_move,
-            }),
-            false => None,
+        unsafe {
+            let entry = *self.entries[idx].get();
+            if entry.key == key { Some(entry) } else { None }
         }
     }
 
-    pub fn store(&self, entry: Entry) {
+    pub fn store(&self, mut entry: Entry) {
         let idx = self.index(entry.key);
-        let current_age = self.age.load(std::sync::atomic::Ordering::Relaxed);
+        let score_type = entry.score_type();
+        entry.set_age_and_type(self.age, score_type);
 
-        let existing_data = TTData::from(&self.entries[idx]);
-        let age_diff = age_diff(current_age, existing_data.age) as u16;
+        let should_write = if let Some(existing_entry) = self.probe(entry.key) {
+            let age_diff = age_diff(self.age, existing_entry.age()) as u16;
 
-        let entry_prio = entry.depth as u16 + entry.score_type as u16 + (age_diff * age_diff) / 4;
-        let existing_prio = existing_data.depth as u16 + existing_data.score_type as u16;
+            let entry_prio = entry.depth as u16 + score_type as u16 + (age_diff * age_diff) / 4;
+            let existing_prio = existing_entry.depth as u16 + existing_entry.score_type() as u16;
 
-        if entry.key != existing_data.key
-            || (entry.score_type == EntryType::Exact
-                && existing_data.score_type != EntryType::Exact)
-            || entry_prio * 3 > existing_prio * 2
-        {
-            let data = TTData {
-                key: entry.key,
-                depth: entry.depth,
-                static_eval: entry.static_eval,
-                score: entry.score,
-                score_type: entry.score_type,
-                best_move: entry.best_move,
-                age: current_age,
-            };
+            entry.key != existing_entry.key
+                || (score_type == EntryType::Exact
+                    && existing_entry.score_type() != EntryType::Exact)
+                || entry_prio * 3 > existing_prio * 2
+        } else {
+            true
+        };
 
-            data.write(&self.entries[idx]);
+        if should_write {
+            unsafe { *self.entries[idx].get() = entry }
         }
     }
 
     pub fn hashfull(&self) -> f64 {
         self.entries[..1000]
             .iter()
-            .filter(|mem| TTData::from(*mem).key != ZobristHash::default())
+            .filter(|e| unsafe {
+                let ptr = e.get();
+                (*ptr).key != ZobristHash::default() && (*ptr).age() == self.age
+            })
             .count() as f64
     }
 }
 
 fn age_diff(current_age: u8, old_age: u8) -> u8 {
-    current_age.wrapping_sub(old_age) & 0x3F // Mask to 6 bits
+    // Both ages are already 6-bit values
+    current_age.wrapping_sub(old_age) & 0x3F
 }
 
 #[cfg(test)]
@@ -253,6 +162,26 @@ mod tests {
 
     #[test]
     fn test_table() {
-        assert_eq!(std::mem::size_of::<TTMemory>(), 16);
+        // Now should be smaller without the separate score_type field
+        assert_eq!(std::mem::size_of::<Entry>(), 16);
+    }
+
+    #[test]
+    fn test_age_and_type_packing() {
+        let mut entry = Entry::default();
+
+        // Test setting different types and ages
+        entry.set_age_and_type(42, EntryType::Exact);
+        assert_eq!(entry.age(), 42);
+        assert_eq!(entry.score_type(), EntryType::Exact);
+
+        entry.set_age_and_type(63, EntryType::LowerBound);
+        assert_eq!(entry.age(), 63);
+        assert_eq!(entry.score_type(), EntryType::LowerBound);
+
+        // Test age wrapping
+        entry.set_age_and_type(64, EntryType::UpperBound);
+        assert_eq!(entry.age(), 0); // 64 & 0x3F = 0
+        assert_eq!(entry.score_type(), EntryType::UpperBound);
     }
 }

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -430,7 +430,7 @@ impl Uci {
         let stop = self.stop.clone();
         let manager = self.manager.clone();
         thread::spawn(move || match manager.try_lock() {
-            Ok(manager) => {
+            Ok(mut manager) => {
                 manager.think_with_stop(limits, stop);
             }
             Err(_) => {


### PR DESCRIPTION
Seems to not actually be needed

```
simplify-tt [completed]
simplify-tt (h@16mb th@1) vs main (h@16mb th@1)

elo = 0.55 [-3.03, 4.01] (95%)
llr = 2.94 (accepted) | sprt = (-5.00, 0.00) [-2.94, 2.94]
wdl = 3860/9451/3807 (22.5%/55.2%/22.2%) | penta = 366/2023/3730/2072/368
games = 17118
```

```
simply [completed]
simplify-tt (h@64mb th@4) vs main (h@64mb th@4)

elo = -0.33 [-3.44, 2.61] (95%)
llr = 2.94 (accepted) | sprt = (-5.00, 0.00) [-2.94, 2.94]
wdl = 5676/14221/5661 (22.2%/55.6%/22.1%) | penta = 581/3162/5317/3099/620
games = 25558
```