### PR TITLE
tweak: reduce score for bad tactical moves

### DIFF
--- a/src/engine/history.rs
+++ b/src/engine/history.rs
@@ -66,7 +66,7 @@ impl HistoryTables {
 
         let mut value = 0;
         let hist_idx = self.history_index(position, mv);
-        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].0 as i32 / 2;
+        value += self.history[hist_idx.0][hist_idx.1][hist_idx.2].0 as i32;
 
         for i in 1..=self.continuation.len() {
             if ply < i {
@@ -74,13 +74,12 @@ impl HistoryTables {
             }
 
             if let Some(c_idx) = self.continuation_index(position, &stack[ply - i], mv) {
-                value += self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].0
-                    as i32
-                    / 2;
+                value +=
+                    self.continuation[i - 1][c_idx.0][c_idx.1][c_idx.2][c_idx.3][c_idx.4].0 as i32;
             }
         }
 
-        value
+        value / 2
     }
 
     pub fn is_killer(&self, ply: usize, mv: Move) -> bool {

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -12,7 +12,7 @@ const GOOD_TACTICAL_SCORE: i32 = 22_000;
 const QUEEN_PROMO_BONUS: i32 = 21_002;
 pub const KILLER_1_SCORE: i32 = 21_001;
 pub const KILLER_2_SCORE: i32 = 21_000;
-const BAD_TACTICAL_SCORE: i32 = -25_000;
+const BAD_TACTICAL_SCORE: i32 = 5_000;
 
 pub const MAX_MOVES: usize = 256;
 

--- a/src/engine/movepicker.rs
+++ b/src/engine/movepicker.rs
@@ -7,12 +7,12 @@ use crate::chess::{Move, Position, Role};
 use crate::engine::history::HistoryTables;
 use crate::engine::search::{Search, Stack};
 
-const TT_MOVE_SCORE: i32 = 30_000;
+const TT_MOVE_SCORE: i32 = 50_000;
 const GOOD_TACTICAL_SCORE: i32 = 22_000;
 const QUEEN_PROMO_BONUS: i32 = 21_002;
 pub const KILLER_1_SCORE: i32 = 21_001;
 pub const KILLER_2_SCORE: i32 = 21_000;
-const BAD_TACTICAL_SCORE: i32 = 17_000;
+const BAD_TACTICAL_SCORE: i32 = -25_000;
 
 pub const MAX_MOVES: usize = 256;
 
@@ -117,7 +117,7 @@ impl MovePicker {
                             if see::see(position, self.scored_moves[i].m, self.margin) {
                                 QUEEN_PROMO_BONUS + GOOD_TACTICAL_SCORE
                             } else {
-                                QUEEN_PROMO_BONUS + BAD_TACTICAL_SCORE
+                                BAD_TACTICAL_SCORE
                             }
                         }
                         _ => BAD_TACTICAL_SCORE,


### PR DESCRIPTION
```
moc [completed]
moveorder-change (h@16mb th@1) vs main (h@16mb th@1)

elo = 15.38 [7.55, 23.27] (95%)
llr = 2.94 (accepted) | sprt = (0.00, 5.00) [-2.94, 2.94]
wdl = 739/1923/590 (22.7%/59.1%/18.1%) | penta = 62/340/696/443/85
games = 3252
```