### PR TITLE
fix: eliminate UB sources that miscompile under LTO

### DIFF
--- a/src/chess/chessmove.rs
+++ b/src/chess/chessmove.rs
@@ -42,7 +42,17 @@ impl Move {
 
     #[inline]
     pub fn promotion(self) -> Option<Role> {
-        unsafe { std::mem::transmute((self.0 >> 12) as u8) }
+        let bits = (self.0 >> 12) as u8;
+        // SAFETY: every Move constructor (`new`, `NONE`, `NULL`) leaves the
+        // top 4 bits in 0..=Role::NUM. Telling the optimizer keeps the
+        // zero-cost codegen the previous `transmute` had, without UB.
+        unsafe { core::hint::assert_unchecked(bits <= Role::NUM as u8) };
+        if bits == Role::NUM as u8 {
+            None
+        } else {
+            // SAFETY: bits ∈ 0..=5 is a valid Role discriminant.
+            Some(unsafe { std::mem::transmute::<u8, Role>(bits) })
+        }
     }
 
     // This only works for valid moves
@@ -96,7 +106,10 @@ impl Move {
         })
     }
 
-    pub const NULL: Move = Move(u16::MAX);
+    // Null move sentinel. Top 4 bits = Role::NUM (the no-promotion sentinel),
+    // so `promotion()` is well-defined on NULL. From/to are both A1, which no
+    // legal move has, so NULL stays distinct from every real move and from NONE.
+    pub const NULL: Move = Move((Role::NUM as u16) << 12);
     pub const NONE: Move = Move(0);
 }
 

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -683,8 +683,11 @@ impl Position {
         // Get both kings' positions
         let our_king_bb = self.our_king();
         let their_king_bb = self.their_king();
-        let our_ksq = Square::new_unchecked(our_king_bb.0.trailing_zeros() as u8);
-        let their_ksq = Square::new_unchecked(their_king_bb.0.trailing_zeros() as u8);
+        // Mask to 6 bits so a king-less bitboard (pathological / corrupted
+        // state) produces Square::A1 instead of an invalid `Square` enum
+        // value, which would be UB when used as an array index.
+        let our_ksq = Square::new_unchecked((our_king_bb.0.trailing_zeros() & 0x3F) as u8);
+        let their_ksq = Square::new_unchecked((their_king_bb.0.trailing_zeros() & 0x3F) as u8);
 
         // Check if we're directly checking the opponent with the piece we just moved
         let dest_bb = Bitboard::from(mv.to());
@@ -741,7 +744,7 @@ impl Position {
         // Update checks and pins for each color
         for color in [Color::White, Color::Black] {
             let king_bb = self.by_color_role(color, Role::King);
-            let ksq = Square::new_unchecked(king_bb.0.trailing_zeros() as u8);
+            let ksq = Square::new_unchecked((king_bb.0.trailing_zeros() & 0x3F) as u8);
             let opponent = color.opponent();
 
             // Direct attacks (knights and pawns)

--- a/src/datagen/format.rs
+++ b/src/datagen/format.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::NonZeroU16;
 
-use anyhow::Context;
+use anyhow::{Context, ensure};
 
 use crate::chess::bitboard::Bitboard;
 use crate::chess::position::CastleRights;
@@ -210,7 +210,13 @@ impl TryFrom<CompressedPosition> for Position {
                 Color::Black
             };
 
-            let role = unsafe { std::mem::transmute::<u8, Role>(pc & 0b111) };
+            let role_bits = pc & 0b111;
+            ensure!(
+                role_bits < Role::NUM as u8,
+                "invalid role bits {role_bits} in compressed position",
+            );
+            // SAFETY: role_bits < Role::NUM is a valid Role discriminant.
+            let role = unsafe { std::mem::transmute::<u8, Role>(role_bits) };
 
             pos.set(sq, Piece { color, role });
         }


### PR DESCRIPTION
Three small, perf-neutral fixes (bench: 3,302,740 nodes, ~0.93 Mnps
both before and after; unit tests green).

1. Move::promotion transmuted an arbitrary u8 into Option<Role>, which
   has a niche-filling layout whose `None` bit pattern is not ABI-stable.
   Bit patterns 0x07..=0x0F produced invalid Option<Role> values, which
   LLVM turned into unreachable/corrupted control flow (confirmed by
   Miri and a standalone segfaulting reproducer). Move::NULL = u16::MAX
   hit this path (top 4 bits = 0xF) every time it was passed into any
   function touching promotion.

   Rewrote promotion() to mask, hint(core::hint::assert_unchecked the
   invariant), and transmute only valid (0..=5) Role discriminants. ASM
   is bit-identical to the old UB version (movzx/shr/ret). Retuned
   Move::NULL to ((Role::NUM as u16) << 12) so the no-promotion sentinel
   is set — NULL stays distinct from every legal move and from NONE.

2. datagen::format.rs transmuted `pc & 0b111` into Role on the disk
   decode path, allowing values 6 and 7 through as invalid Role
   discriminants. Replaced with an `ensure!` guard + Result error.

3. update_checks_and_pins extracted king squares via
   Square::new_unchecked(bb.trailing_zeros() as u8). A king-less
   bitboard (pathological or corruption-induced) returns 64 and would
   produce an invalid Square enum, UB when used as an array index.
   Masking to 6 bits costs one AND instruction and bounds the damage to
   "wrong square" instead of out-of-bounds array read.