### PR TITLE
fix: silence clippy needless_range_loop in wiz magic_finder

### DIFF
--- a/src/bin/wiz/magic_finder.rs
+++ b/src/bin/wiz/magic_finder.rs
@@ -25,6 +25,7 @@ impl Wizard {
 
         for sq in Square::ALL.into_iter() {
             let r_mask = rook_mask(sq);
+            #[allow(clippy::needless_range_loop)]
             for i in 0..1 << r_mask.count() {
                 let occupancy = occupancy_bb(&r_mask, i);
                 r_attacks[sq as usize][i] = rook_attacks(sq, occupancy);
@@ -32,6 +33,7 @@ impl Wizard {
             r_masks[sq] = r_mask;
 
             let b_mask = bishop_mask(sq);
+            #[allow(clippy::needless_range_loop)]
             for i in 0..1 << b_mask.count() {
                 let occupancy = occupancy_bb(&b_mask, i);
                 b_attacks[sq as usize][i] = bishop_attacks(sq, occupancy);


### PR DESCRIPTION
## Summary
- `main`'s `clippy` CI job has been red since #135 (2025-12-09) — newer stable clippy enforces `needless_range_loop` on the index loops in `src/bin/wiz/magic_finder.rs` (untouched since #35).
- The loops index `r_attacks[sq][i]`/`b_attacks[sq][i]` and reuse `i` for `occupancy_bb`, so an iterator rewrite is awkward; allow the lint, consistent with the existing `#[allow(clippy::needless_range_loop)]` in `src/engine/search.rs`.
- Not caused by recent work; this restores `main` CI to green.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally (exact CI command)